### PR TITLE
Set permission by uid and gid on the webroot folder

### DIFF
--- a/imageroot/actions/create-vhost/10base
+++ b/imageroot/actions/create-vhost/10base
@@ -67,9 +67,6 @@ config['vhost']['MaxFileUploads'] = str(MaxFileUploads)
 with open( 'databases/vhosts/' + str(NextFpmPort)+'.ini', 'w') as configfile:
     config.write(configfile)
 
-# we need to create the webroot folder for the website
-subprocess.run(["podman","exec","-i","nginx","mkdir","-p","/usr/share/nginx/html/"+str(NextFpmPort)])
-
 # we need to create the user in sftpgo
 
 f = open ('sftpgo.conf.d/API_KEY', "r")
@@ -94,7 +91,7 @@ os.chmod('sftpgo.conf.d/secrets/'+str(NextFpmPort)+'.secret', 0o600)
 # connect to sftpgo api and create the user username === NextFpmPort
 conn = http.client.HTTPConnection("localhost:"+os.environ["SFTPGO_TCP_PORT"])
 
-payload = '{"id":1,"status":1,"username":"'+str(NextFpmPort)+'","expiration_date":0,"password":"'+password+'","home_dir":"/srv/sftpgo/data/'+str(NextFpmPort)+'","uid":0,"gid":0,"max_sessions":0,"quota_size":0,"quota_files":0,"permissions":{"/":["*"]},"created_at":0,"updated_at":0,"filters":{"tls_username":"None","hooks":{"external_auth_disabled":false,"pre_login_disabled":false,"check_password_disabled":false},"totp_config":{"secret":{}}},"filesystem":{"provider":0,"s3config":{"access_secret":{}},"gcsconfig":{"credentials":{}},"azblobconfig":{"account_key":{},"sas_url":{}},"cryptconfig":{"passphrase":{}},"sftpconfig":{"password":{},"private_key":{}}}}'
+payload = '{"id":1,"status":1,"username":"'+str(NextFpmPort)+'","expiration_date":0,"password":"'+password+'","home_dir":"/srv/sftpgo/data/'+str(NextFpmPort)+'","uid":1,"gid":'+str(NextFpmPort)+',"max_sessions":0,"quota_size":0,"quota_files":0,"permissions":{"/":["*"]},"created_at":0,"updated_at":0,"filters":{"tls_username":"None","hooks":{"external_auth_disabled":false,"pre_login_disabled":false,"check_password_disabled":false},"totp_config":{"secret":{}}},"filesystem":{"provider":0,"s3config":{"access_secret":{}},"gcsconfig":{"credentials":{}},"azblobconfig":{"account_key":{},"sas_url":{}},"cryptconfig":{"passphrase":{}},"sftpconfig":{"password":{},"private_key":{}}}}'
 
 headers = {
     'Content-Type': "application/json",

--- a/imageroot/templates/php-fpm-pool.conf
+++ b/imageroot/templates/php-fpm-pool.conf
@@ -1,6 +1,6 @@
 [{{WebRoot}}]
 user = daemon
-group = daemon
+group = {{port}}
 listen = {{port}}
 pm = ondemand
 pm.max_children = 5


### PR DESCRIPTION
Set the uid 1 and a specific (unique) gid on the web root folder
The webroot folder is created at the first sftp upload by sftpgo of by the sftp  CLI

review of https://github.com/NethServer/ns8-webserver/pull/1
