### PR TITLE
Fix the node hostname in case of remote node

### DIFF
--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -26,6 +26,8 @@ import configparser
 import json
 import sys
 import agent
+import socket
+
 configuration = {}
 vhosts = []
 for file in glob.iglob("databases/vhosts/*.ini"):
@@ -58,6 +60,8 @@ fp.close()
 
 configuration['NextFpmPort'] = NextFpmPort
 
+# Find the hosname of the node
+configuration["hostname"] = socket.gethostname()
 
 # Read current configuration from Redis
 env = f'module/{os.environ["MODULE_ID"]}/environment'

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -25,7 +25,8 @@
             ],
             "sftp_tcp_port": 20014,
             "path": "/sftpgo",
-            "http2https": true
+            "http2https": true,
+            "hostname": "foo.domain.com"
         }
     ],
     "type": "object",
@@ -33,7 +34,8 @@
         "path",
         "http2https",
         "sftp_tcp_port",
-        "virtualhost"
+        "virtualhost",
+        "hostname"
     ],
     "properties": {
         "http2https": {
@@ -50,6 +52,11 @@
             "type": "string",
             "description": "web path for the web application, like '/sftpgo'",
             "pattern": "^/?[a-zA-Z0-9_-]+/?$"
+        },
+        "hostname": {
+            "description": "Host name of the node, like 'foo.domain.com'",
+            "format": "idn-hostname",
+            "title": "hostname of the node"
         }
     },
     "virtualhost": {

--- a/ui/src/views/Status.vue
+++ b/ui/src/views/Status.vue
@@ -364,7 +364,7 @@ export default {
       urlCheckInterval: null,
       isRedirectChecked: false,
       redirectTimeout: 0,
-      hostname: location.hostname,
+      hostname: "",
       status: {
         instance: "",
         services: [],
@@ -488,6 +488,7 @@ export default {
       const config = taskResult.output;
       this.sftp_tcp_port = config.sftp_tcp_port;
       this.path = config.path
+      this.hostname = config.hostname
       this.loading.getConfiguration = false;
     },
     async getStatus() {

--- a/ui/src/views/VirtualHosts.vue
+++ b/ui/src/views/VirtualHosts.vue
@@ -379,7 +379,7 @@ export default {
       UploadMaxFilesize:"",
       virtualhost: [],
       NextFpmPort:"",
-      hostname: location.hostname,
+      hostname: "",
       urlCheckInterval: null,
       loading: {
         getConfiguration: false,
@@ -505,6 +505,7 @@ export default {
       this.NextFpmPort = config.NextFpmPort;
       this.sftp_tcp_port = config.sftp_tcp_port;
       this.path = config.path
+      this.hostname = config.hostname
       this.loading.getConfiguration = false;
     },
 


### PR DESCRIPTION
When you install the webserver on the remote node the UI sends back in the web link  the hostname of the leader node which runs the UI and not the hostname of the remote node 