### PR TITLE
Create a random web path for sftpgo application

### DIFF
--- a/imageroot/actions/create-module/20traefik
+++ b/imageroot/actions/create-module/20traefik
@@ -27,9 +27,10 @@ import sys
 import json
 import agent
 import agent.tasks
+import secrets
 
 # Setup default values
-path = '/sftpgo'
+path = '/' + secrets.token_hex(10)
 h2hs = True
 
 # Talk with agent using file descriptor.


### PR DESCRIPTION
In case of multi webserver installation on the same node we cannot use the same path as the default installation

the default was to create a web path `/sftpgo` but I forgot that you could install many module on the same web path at beginning, therefore I need a random web path that people could change as wanted after the installation if the web does not please them

example : 

```
>>> secrets.token_hex(10)
'c0483d39609b784520d3'
```