### PR TITLE
sftpgo.service. do a loop to wait the service is fully up

### DIFF
--- a/imageroot/systemd/user/sftpgo.service
+++ b/imageroot/systemd/user/sftpgo.service
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/sftpgo.pid \
     --env SFTPGO_HTTPD__WEB_ROOT=${TRAEFIK_PATH}\
     --user 0:0 \
     ${SFTPGO_IMAGE}
+ExecStartPost=/usr/bin/bash -c "while ! exec 3<>/dev/tcp/127.0.0.1/${SFTP_TCP_PORT} &>/dev/null; do sleep 3 ; done ; printf 'GET /ping\r\n\r\n' >&3"
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/sftpgo.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/sftpgo.ctr-id
 PIDFile=%t/sftpgo.pid


### PR DESCRIPTION
In some condition we could have a sftpgo container not fully started and the action 60sftpgo_create_secret which tries to connect to the sftpgo api