### PR TITLE
Timers to update php-fpm

### DIFF
--- a/imageroot/actions/create-module/05EnableTimer
+++ b/imageroot/actions/create-module/05EnableTimer
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e    # exit immediately if an error occurs
+exec 1>&2 # ensure any output is sent to stderr
+
+systemctl --user enable --now phpFpm.timer

--- a/imageroot/bin/update-php-fpm
+++ b/imageroot/bin/update-php-fpm
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import os
+import sys
+import subprocess
+import glob
+import re
+
+#
+# Find enabled service and upgrade the image of the container, restart the service
+#
+
+PhpServiceArray = glob.glob('php*-fpm-custom.d')
+for folder in PhpServiceArray:
+    ConfiguredServices = re.findall('php[0-9\.]+', folder)
+    ListConfigurations = glob.glob(folder+'/*.conf')
+    if ListConfigurations :
+        subprocess.run(["podman","pull","bitnami/php-fpm:"+ConfiguredServices[0].replace('php','')])
+        subprocess.run(["systemctl", "--user", "restart", "phpfpm@"+ConfiguredServices[0].replace('php','')+".service"])

--- a/imageroot/systemd/user/phpFpm.service
+++ b/imageroot/systemd/user/phpFpm.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Timer of the update of phpFpm pool
+
+[Service]
+Type=oneshot
+ExecStart=runagent update-php-fpm
+SyslogIdentifier=%u/%N

--- a/imageroot/systemd/user/phpFpm.timer
+++ b/imageroot/systemd/user/phpFpm.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Timer of the update of phpFpm pool
+
+[Timer]
+OnCalendar=monthly
+RandomizedDelaySec=3600
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
We use a fixed name to pull the fpm container image, let's say `docker.io/bitnami/php-fpm:8.1` but this image could be updated weekly to a minor version, (Example 8.1.18 to 8.1.19)

the plan is to trigger a timer monthly to update the image and restart the php-fpm service


https://trello.com/c/DGh7pYca/390-upgrade-php-fpm-image-of-webserver