### PR TITLE
Wait the first time after slow system

### DIFF
--- a/imageroot/actions/configure-module/60sftpgo_create_secret
+++ b/imageroot/actions/configure-module/60sftpgo_create_secret
@@ -26,10 +26,14 @@ import os
 import sys
 import json
 import http.client
+import time
 
 if os.path.isfile("sftpgo.conf.d/API_KEY"):
     sys.exit(0)
 else:
+    # we start sftpgo for the first ever time, next we exit early
+    # we need to wait a bit mainly for slow system
+    time.sleep(10)
     conn = http.client.HTTPConnection("localhost:"+os.environ["SFTPGO_TCP_PORT"])
 
     # create the short TTL token


### PR DESCRIPTION
With slow system we have an issue when the sftpgo container is not fully started and we try to initiate the first configuration. It seems that without the first configuration we cannot check the healtchek of the container  https://sftpgo.stoplight.io/docs/sftpgo/ae095616e4a79-health-check and the sftpgo container is able to answer to the systemd post action ping whereas it is not fully started or responsive.

Not the best fix but we need to wait

https://community.nethserver.org/t/ns8-configure-nginx-fails/21678/

```
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]: Traceback (most recent call last):
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]:   File "/home/webserver1/.config/actions/configure-module/60sftpgo_create_secret", line 44, in <module>
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]:     res = conn.getresponse()
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]:   File "/usr/lib64/python3.9/http/client.py", line 1377, in getresponse
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]:     response.begin()
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]:   File "/usr/lib64/python3.9/http/client.py", line 320, in begin
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]:     version, status, reason = self._read_status()
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]:   File "/usr/lib64/python3.9/http/client.py", line 281, in _read_status
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]:     line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]:   File "/usr/lib64/python3.9/socket.py", line 704, in readinto
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]:     return self._sock.recv_into(b)
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]: ConnectionResetError: [Errno 104] Connection reset by peer
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[10294]: {"level":"info","time":"2023-06-07T18:55:07.271","sender":"httpd","message":"server listener registered, address: [::]:8080 TLS enabled: false"}
Jun 07 20:55:07 R3-pve.rocky9-pve3.org webserver1[9762]: task/module/webserver1/21db2e7c-5d13-4670-b968-9b24ece99a25: action "configure-module" status is "aborted" (1) at step 60sftpgo_create_secret

```