### PR TITLE
download and tag x.y.z php version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This module use nginx and php-fpm to make a a linux apache mysql (see ns8-mariadb) and php
 
+# update PHP or add new versions
+
+To add new version inside the UI go to ui/src/views/VirtualHosts.vue in the php dropdown. The UI uses the minor version 8.1 but we need to pull the phpfpm container 8.1.30. This is done in imageroot/bin/download-php-fpm, please upgrade from time to time the php version wanted there, the upgrade script imageroot/update-module.d/20restart will pull and restart phpfpm service.
+
 ## local database
 
 We use local database to store configuration, you can find it `/home/webserver*/.config/state/databases/vhosts/*.ini`, the TCP port of php-fpm which is unique, is used as an ID, so the first vhost configuration databse will be at 

--- a/imageroot/actions/create-vhost/30SystemdServices
+++ b/imageroot/actions/create-vhost/30SystemdServices
@@ -35,6 +35,8 @@ if PhpVersion:
     os.makedirs('php'+str(PhpVersion)+'-fpm-custom.d', exist_ok=True)
     # expand configuration
     subprocess.run(["systemctl", "--user", "reload", "nginx.service"])
+    # pull the image if missing
+    subprocess.run(["download-php-fpm",str(PhpVersion)])
     # start the container  if stopped
     subprocess.run(["systemctl", "--user", "enable", "--now", "phpfpm@"+str(PhpVersion)+".service"])
 else:

--- a/imageroot/actions/update-vhost/30SystemdServices
+++ b/imageroot/actions/update-vhost/30SystemdServices
@@ -47,7 +47,8 @@ if PhpVersion:
         ListConfigurations = glob.glob(folder+'/*.conf')
         if not ListConfigurations :
             subprocess.run(["systemctl", "--user", "disable","--now", "phpfpm@"+ConfiguredServices[0].replace('php','')+".service"])
-
+    # pull the image if missing
+    subprocess.run(["download-php-fpm",str(PhpVersion)])
     # start the container  if stopped
     subprocess.run(["systemctl", "--user", "enable", "--now", "phpfpm@"+str(PhpVersion)+".service"])
     subprocess.run(["systemctl", "--user", "reload", "phpfpm@\*.service"])

--- a/imageroot/bin/download-php-fpm
+++ b/imageroot/bin/download-php-fpm
@@ -7,29 +7,22 @@
 set -e
 # we download image and tag it with major version
 
-if [[ $# -ne 1 ]]; then
-    echo "We expect one argument"
-    exit 1
-fi
+major_version="${1:?We expect one argument}"
 
+declare -A version_map
 
-major_version=$1
-
-if [[ $major_version == "7.4" ]]; then
-    minor_version="7.4.33"
-elif [[ $major_version == "8.0" ]]; then
-    minor_version="8.0.29"
-elif [[ $major_version == "8.1" ]]; then
-    minor_version="8.1.20"
-elif [[ $major_version == "8.2" ]]; then
-    minor_version="8.2.7"
-else
-    echo "We expect a major php version (7.4,8.0,8.1,8.2)"
+version_map[7.4]=7.4.33
+version_map[8.0]=8.0.29
+version_map[8.1]=8.1.20
+version_map[8.2]=8.2.7
+# Check if major_version is mapped properly
+if [[ -z "${version_map[$major_version]}" ]]; then
+    echo "PHP version $major_version is not supported" 1>&2
     exit 1
 fi
 
 # pull the image
-/usr/bin/podman pull docker.io/bitnami/php-fpm:${minor_version}
+podman-pull-missing "docker.io/bitnami/php-fpm:${version_map[$major_version]}"
 # systemd service use docker.io/bitnami/php-fpm:8.1 
 # we need to tag with major version to use it locally
-/usr/bin/podman tag  docker.io/bitnami/php-fpm:${minor_version} docker.io/bitnami/php-fpm:${major_version}
+/usr/bin/podman tag  "docker.io/bitnami/php-fpm:${version_map[$major_version]}" "docker.io/bitnami/php-fpm:${major_version}"

--- a/imageroot/bin/download-php-fpm
+++ b/imageroot/bin/download-php-fpm
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+set -e
+# we download image and tag it with major version
+
+if [[ $# -ne 1 ]]; then
+    echo "We expect one argument"
+    exit 1
+fi
+
+
+major_version=$1
+
+if [[ $major_version == "7.4" ]]; then
+    minor_version="7.4.33"
+elif [[ $major_version == "8.0" ]]; then
+    minor_version="8.0.29"
+elif [[ $major_version == "8.1" ]]; then
+    minor_version="8.1.20"
+elif [[ $major_version == "8.2" ]]; then
+    minor_version="8.2.7"
+else
+    echo "We expect a major php version (7.4,8.0,8.1,8.2)"
+    exit 1
+fi
+
+# pull the image
+/usr/bin/podman pull docker.io/bitnami/php-fpm:${minor_version}
+# systemd service use docker.io/bitnami/php-fpm:8.1 
+# we need to tag with major version to use it locally
+/usr/bin/podman tag  docker.io/bitnami/php-fpm:${minor_version} docker.io/bitnami/php-fpm:${major_version}

--- a/imageroot/bin/download-php-fpm
+++ b/imageroot/bin/download-php-fpm
@@ -7,7 +7,7 @@
 set -e
 # we download image and tag it with major version
 
-major_version="${1:?We expect one argument}"
+minor_version="${1:?We expect one argument}"
 
 declare -A version_map
 
@@ -16,13 +16,13 @@ version_map[8.0]=8.0.29
 version_map[8.1]=8.1.20
 version_map[8.2]=8.2.7
 # Check if major_version is mapped properly
-if [[ -z "${version_map[$major_version]}" ]]; then
-    echo "PHP version $major_version is not supported" 1>&2
+if [[ -z "${version_map[$minor_version]}" ]]; then
+    echo "PHP version $minor_version is not supported" 1>&2
     exit 1
 fi
 
 # pull the image
-podman-pull-missing "docker.io/bitnami/php-fpm:${version_map[$major_version]}"
+podman-pull-missing "docker.io/bitnami/php-fpm:${version_map[$minor_version]}"
 # systemd service use docker.io/bitnami/php-fpm:8.1 
 # we need to tag with major version to use it locally
-/usr/bin/podman tag  "docker.io/bitnami/php-fpm:${version_map[$major_version]}" "docker.io/bitnami/php-fpm:${major_version}"
+/usr/bin/podman tag  "docker.io/bitnami/php-fpm:${version_map[$minor_version]}" "docker.io/bitnami/php-fpm:${minor_version}"

--- a/imageroot/systemd/user/phpfpm@.service
+++ b/imageroot/systemd/user/phpfpm@.service
@@ -12,7 +12,6 @@ Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/php%i-fpm.pid %t/php%i-fpm.ctr-id
 ExecStartPre=/usr/bin/mkdir -p %S/state/php%i-fpm-custom.d
-ExecStartPre=runagent download-php-fpm %i
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/php%i-fpm.pid \
     --cidfile %t/php%i-fpm.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/webserver.pod-id --replace -d --name  php%i-fpm \

--- a/imageroot/systemd/user/phpfpm@.service
+++ b/imageroot/systemd/user/phpfpm@.service
@@ -12,6 +12,7 @@ Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/php%i-fpm.pid %t/php%i-fpm.ctr-id
 ExecStartPre=/usr/bin/mkdir -p %S/state/php%i-fpm-custom.d
+ExecStartPre=runagent download-php-fpm %i
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/php%i-fpm.pid \
     --cidfile %t/php%i-fpm.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/webserver.pod-id --replace -d --name  php%i-fpm \

--- a/imageroot/update-module.d/20restart
+++ b/imageroot/update-module.d/20restart
@@ -36,4 +36,5 @@ for folder in PhpServiceArray:
     ConfiguredServices = re.findall('php[0-9\.]+', folder)
     ListConfigurations = glob.glob(folder+'/*.conf')
     if ListConfigurations :
+        subprocess.run(["download-php-fpm",ConfiguredServices[0].replace('php','')])
         subprocess.run(["systemctl", "--user", "try-restart", "phpfpm@"+ConfiguredServices[0].replace('php','')+".service"])


### PR DESCRIPTION
We use fixed version of php, before to start the container we pull the image and we tag it with a major version to use it locally

When we upgrade the module, before to restart the phpfpm@{7.4,8.0,8.1,8.2}.service we pull the image