### PR TITLE
Check sftpgo health before to fully start the systemd service

### DIFF
--- a/imageroot/actions/configure-module/60sftpgo_create_secret
+++ b/imageroot/actions/configure-module/60sftpgo_create_secret
@@ -26,14 +26,10 @@ import os
 import sys
 import json
 import http.client
-import time
 
 if os.path.isfile("sftpgo.conf.d/API_KEY"):
     sys.exit(0)
 else:
-    # we start sftpgo for the first ever time, next we exit early
-    # we need to wait a bit mainly for slow system
-    time.sleep(10)
     conn = http.client.HTTPConnection("localhost:"+os.environ["SFTPGO_TCP_PORT"])
 
     # create the short TTL token

--- a/imageroot/systemd/user/sftpgo.service
+++ b/imageroot/systemd/user/sftpgo.service
@@ -20,7 +20,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/sftpgo.pid \
     --env SFTPGO_HTTPD__WEB_ROOT=${TRAEFIK_PATH}\
     --user 0:0 \
     ${SFTPGO_IMAGE}
-ExecStartPost=/usr/bin/bash -c "while ! exec 3<>/dev/tcp/127.0.0.1/${SFTP_TCP_PORT} &>/dev/null; do sleep 3 ; done ; printf 'GET /ping\r\n\r\n' >&3"
+ExecStartPost=/usr/bin/bash -c "while ! curl --request GET --url http://localhost:${SFTPGO_TCP_PORT}/healthz --header 'Accept: text/plain; charset=utf-8' &>/dev/null; do sleep 3 ; done"
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/sftpgo.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/sftpgo.ctr-id
 PIDFile=%t/sftpgo.pid


### PR DESCRIPTION
We could have issue when we install webserver on slow machine with slow drive IO

We need to be sure sftpgo is fully up the first time before to continue to create the API key to set up sftpgo