### PR TITLE
webserver move to another node is broken

### DIFF
--- a/imageroot/actions/clone-module/06copyenv
+++ b/imageroot/actions/clone-module/06copyenv
@@ -1,1 +1,0 @@
-../restore-module/06copyenv

--- a/imageroot/actions/clone-module/60pull-php-image
+++ b/imageroot/actions/clone-module/60pull-php-image
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+import subprocess
+import glob
+import re
+
+# detect if a service has configurations, and pull image php
+PhpServiceArray = glob.glob('php*-fpm-custom.d')
+for folder in PhpServiceArray:
+    ConfiguredServices = re.findall('php[0-9\.]+', folder)
+    ListConfigurations = glob.glob(folder+'/*.conf')
+    if ListConfigurations :
+        subprocess.run(["download-php-fpm",ConfiguredServices[0].replace('php','')])

--- a/imageroot/actions/clone-module/60systemd
+++ b/imageroot/actions/clone-module/60systemd
@@ -1,1 +1,0 @@
-../restore-module/60systemd


### PR DESCRIPTION
During the move to another node we have an issue 

```
Jun 15 14:59:42 R2-pve.rocky9-pve2.org webserver6[2102]: task/module/webserver6/3febebd3-cab3-430a-b64b-945937d0bac9: clone-module/06copyenv is starting
Jun 15 14:59:43 R2-pve.rocky9-pve2.org webserver6[2102]: Traceback (most recent call last):
Jun 15 14:59:43 R2-pve.rocky9-pve2.org webserver6[2102]:   File "/home/webserver6/.config/actions/clone-module/06copyenv", line 29, in <module>
Jun 15 14:59:43 R2-pve.rocky9-pve2.org webserver6[2102]:     original_environment = request['environment']
Jun 15 14:59:43 R2-pve.rocky9-pve2.org webserver6[2102]: KeyError: 'environment'
Jun 15 14:59:43 R2-pve.rocky9-pve2.org webserver6[2102]: task/module/webserver6/3febebd3-cab3-430a-b64b-945937d0bac9: action "clone-module" status is "aborted" (1) at step 06copyenv

```

looking how it works with another module we just need to configure traefik by a hard link to `../restore-module/50traefik` and to pull php image because systemd does not handle it alone (we need to pull 8.2.7 and tag theimage to 8.2)