### PR TITLE
Upgrade SFTPGo 2.5.5  and Nginx 1.25.3

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -30,7 +30,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=node:fwadm traefik@node:routeadm" \
     --label="org.nethserver.tcp-ports-demand=2" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/nginx:1.24-alpine docker.io/drakkan/sftpgo:v2.5.1-alpine" \
+    --label="org.nethserver.images=docker.io/nginx:1.25.3-alpine docker.io/drakkan/sftpgo:v2.5.5-alpine" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"


### PR DESCRIPTION
We have EOL coming for nginx (april 2024) and new version of SFTPGo 2.5.5

https://nginx.org/en/CHANGES
https://github.com/drakkan/sftpgo/releases