### PR TITLE
Update SFTP TCP Port placeholder and type

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -91,7 +91,7 @@
     "path_pattern": "Web path for the web application, like '/sftpgo'",
     "webpath_already_used_in_traefik": "This web path is already used by another application in the web proxy.",
     "sftp_tcp_port": "External sftp TCP port",
-    "sftp_tcp_port_tips": "This port is needed to connect a sftp client to the sftp server: sftp -P port_number user@hostname",
+    "sftp_tcp_port_tips": "This port is needed to connect a sftp client to the sftp server: sftp -P {port} user@hostname",
     "save": "Save",
     "lets_encrypt": "Let's Encrypt",
     "http_to_https": "HTTP to HTTPS",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -4,7 +4,8 @@
     "work_in_progress": "Work in progress",
     "processing": "Processing...",
     "enabled":"Enabled",
-    "disabled":"Disabled"
+    "disabled":"Disabled",
+    "eg_value": "E.g. {value}"
   },
   "status": {
     "title": "Status",

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -45,7 +45,7 @@
                 <template slot="tooltip">
                   <div
                     v-html="
-                      $t('settings.sftp_tcp_port_tips', {port: sftp_tcp_port})
+                      $t('settings.sftp_tcp_port_tips', {port: sftp_tcp_port || 'tcp_port'})
                     "
                   ></div>
                 </template>

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -45,7 +45,7 @@
                 <template slot="tooltip">
                   <div
                     v-html="
-                      $t('settings.sftp_tcp_port_tips', {port: sftp_tcp_port || 'tcp_port'})
+                      $t('settings.sftp_tcp_port_tips', {port: sftp_tcp_port || '{tcp_port}'})
                     "
                   ></div>
                 </template>

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -32,7 +32,7 @@
               </cv-text-input>
               <NsTextInput
                 :label="$t('settings.sftp_tcp_port')"
-                placeholder="e.g. 3092"
+                :placeholder="$t('common.eg_value', {value: '3092'})"
                 type="number"
                 v-model.trim="sftp_tcp_port"
                 class="mg-bottom"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -32,7 +32,8 @@
               </cv-text-input>
               <NsTextInput
                 :label="$t('settings.sftp_tcp_port')"
-                placeholder="3092"
+                placeholder="e.g. 3092"
+                type="number"
                 v-model.trim="sftp_tcp_port"
                 class="mg-bottom"
                 :invalid-message="$t(error.sftp_tcp_port)"
@@ -44,7 +45,7 @@
                 <template slot="tooltip">
                   <div
                     v-html="
-                      $t('settings.sftp_tcp_port_tips')
+                      $t('settings.sftp_tcp_port_tips', {port: sftp_tcp_port})
                     "
                   ></div>
                 </template>
@@ -214,7 +215,7 @@ export default {
     getConfigurationCompleted(taskContext, taskResult) {
       const config = taskResult.output;
       this.path = config.path;
-      this.sftp_tcp_port = config.sftp_tcp_port;
+      this.sftp_tcp_port = config.sftp_tcp_port.toString();
       this.isHttpToHttpsEnabled = config.http2https;
       this.isSftpgoPortEnabled = config.sftpgo_service
       this.loading.getConfiguration = false;


### PR DESCRIPTION
This pull request updates the SFTP TCP Port placeholder and type in the Settings view. The placeholder has been changed to "e.g. 3092" and the input type has been set to "number". This makes it clearer for users to enter the desired port number. Additionally, the translation for the tooltip has been updated to include the actual port number entered by the user. This improves the user experience and provides better guidance when configuring the SFTP TCP Port.

![image](https://github.com/NethServer/ns8-webserver/assets/3164851/600bf339-7d66-43b6-aae2-063646fa934d)
![image](https://github.com/NethServer/ns8-webserver/assets/3164851/c28eefcc-e65b-4d66-95dd-7fc7fe9d0156)
![image](https://github.com/NethServer/ns8-webserver/assets/3164851/13fb4bf0-1b43-4f89-985c-eaf8d9760500)

https://github.com/NethServer/dev/issues/6788