### PR TITLE
Fix validation pattern for ServerNames in create-vhost and update-vhost

### DIFF
--- a/imageroot/actions/create-vhost/validate-input.json
+++ b/imageroot/actions/create-vhost/validate-input.json
@@ -41,9 +41,10 @@
         "ServerNames": {
             "type": "array",
             "items": {
-            "type": "string",
-            "format":"hostname"
-        },
+                "type": "string",
+                "format": "hostname",
+                "pattern": "\\."
+            },
             "title": "ServerNames",
             "description": "Fully qualified domain names as virtualhost."
         },

--- a/imageroot/actions/update-vhost/validate-input.json
+++ b/imageroot/actions/update-vhost/validate-input.json
@@ -42,7 +42,8 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "format": "hostname"
+                "format": "hostname",
+                "pattern": "\\."
             },
             "title": "ServerNames",
             "description": "Fully qualified domain names as virtualhost."

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -77,6 +77,7 @@
     "Edit_Virtualhosts":"Edit virtual host {name}",
     "title": "Virtual hosts",
     "ServerNames_format": "Domain name not allowed : {error}",
+    "ServerNames_pattern": "Must be a valid fully qualified domain name: {error}",
     "type_to_confirm": "Type <strong>{name}</strong> to confirm deletion",
     "delete_virtualhosts_confirm": "Delete virtual host <strong>{name}</strong>? All data will be deleted. This action is <strong>NOT</strong> reversible",
     "sftpgo_url": "SFTPGo WebClient",


### PR DESCRIPTION
This pull request fixes the validation pattern for the ServerNames field in the create-vhost and update-vhost actions. The pattern now requires a valid fully qualified domain name and disallows domain names with a dot at the end.

https://github.com/NethServer/dev/issues/6853