### PR TITLE
Update PHP versions to include PHP 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ Send a test HTTP request to the webserver backend service:
 
 a vhost can be created by the api-cli command
 
-We use a container with nginx and another container for the php-fpm configuration (actually availlable PHP 7.4,8.0,8.1,8.2)
+We use a container with nginx and another container for the php-fpm configuration (actually availlable PHP 7.4,8.0,8.1,8.2,8.3)
 
 Launch `create-vhost`, by setting the following parameters:
-- `PhpVersion`: Set the version of php needed, can be `''(no php), 7.4,8.0,8.1,8.2`
+- `PhpVersion`: Set the version of php needed, can be `''(no php), 7.4,8.0,8.1,8.2,8.3`
 - `ServerNames`: set the domain name of the vhost, it must be an array
 - `MemoryLimit`: This sets the maximum amount of memory that a script is allowed to allocate. use `MB`
 - `AllowUrlfOpen` : This option enables the URL-aware fopen wrappers that enable accessing URL object like files. use `enabled|disabled`
@@ -184,7 +184,7 @@ The TCP port of the php-fpm port is unique, each virtualhost gets a nex tcp port
 
 Launch `update-vhost`, by setting the following parameters:
 - `port`: The tcp port of php-fpm, it is used as an ID for the virtualhost
-- `PhpVersion`: Set the version of php needed, can be `''(no php), 7.4,8.0,8.1,8.2`
+- `PhpVersion`: Set the version of php needed, can be `''(no php), 7.4,8.0,8.1,8.2,8.3`
 - `ServerNames`: set the domain name of the vhost, it must be an array
 - `MemoryLimit`: This sets the maximum amount of memory that a script is allowed to allocate. use `MB`
 - `AllowUrlfOpen` : This option enables the URL-aware fopen wrappers that enable accessing URL object like files. use `enabled|disabled`

--- a/imageroot/actions/create-vhost/validate-input.json
+++ b/imageroot/actions/create-vhost/validate-input.json
@@ -53,7 +53,7 @@
             "format": "regex",
             "pattern":"(^[0-9][.][0-9]$|^$)",
             "title": "PhpVersion",
-            "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or ''"
+            "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or 8.3 or ''"
         },
         "MemoryLimit": {
             "type": "integer",

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -102,7 +102,7 @@
                         "format": "regex",
                         "pattern": "(^[0-9][.][0-9]$|^$)",
                         "title": "PhpVersion",
-                        "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or ''"
+                        "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or 8.3 or ''"
                     },
                     "MemoryLimit": {
                         "type": "integer",

--- a/imageroot/actions/update-vhost/validate-input.json
+++ b/imageroot/actions/update-vhost/validate-input.json
@@ -53,7 +53,7 @@
             "format": "regex",
             "pattern": "(^[0-9][.][0-9]$|^$)",
             "title": "PhpVersion",
-            "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or ''"
+            "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or 8.3 or ''"
         },
         "MemoryLimit": {
             "type": "integer",

--- a/imageroot/bin/download-php-fpm
+++ b/imageroot/bin/download-php-fpm
@@ -14,7 +14,8 @@ declare -A version_map
 version_map[7.4]=7.4.33
 version_map[8.0]=8.0.30
 version_map[8.1]=8.1.27
-version_map[8.2]=8.2.16
+version_map[8.2]=8.2.17
+version_map[8.3]=8.3.4
 # Check if major_version is mapped properly
 if [[ -z "${version_map[$minor_version]}" ]]; then
     echo "PHP version $minor_version is not supported" 1>&2

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -49,6 +49,7 @@
     "PHP_80":"PHP 8.0",
     "PHP_81":"PHP 8.1",
     "PHP_82":"PHP 8.2",
+    "PHP_83":"PHP 8.3",
     "container_version_will_be_installed":"Changing PHP version will install a new PHP container: configuration might take a while",
     "select_php_version":"Version of PHP",
     "AllowUrlfOpen":"URL-aware fopen wrappers",

--- a/ui/src/views/VirtualHosts.vue
+++ b/ui/src/views/VirtualHosts.vue
@@ -224,6 +224,7 @@
             <cv-dropdown-item value="8.0">{{$t('virtualhosts.PHP_80')}}</cv-dropdown-item>
             <cv-dropdown-item value="8.1">{{$t('virtualhosts.PHP_81')}}</cv-dropdown-item>
             <cv-dropdown-item value="8.2">{{$t('virtualhosts.PHP_82')}}</cv-dropdown-item>
+            <cv-dropdown-item value="8.3">{{$t('virtualhosts.PHP_83')}}</cv-dropdown-item>
           </cv-dropdown>
           <!-- advanced options -->
           <cv-accordion ref="accordion">


### PR DESCRIPTION
This pull request updates the PHP versions in the create-vhost and update-vhost commands to include PHP 8.3. It also updates the PhpVersion descriptions in the validate-input.json and validate-output.json files. Additionally, it adds PHP 8.3 to the translation.json file and includes it as an option in the VirtualHosts dropdown in the VirtualHosts.vue file.