### PR TITLE
Webserver : create the web folder with create folder

### DIFF
--- a/imageroot/actions/create-vhost/10base
+++ b/imageroot/actions/create-vhost/10base
@@ -89,3 +89,5 @@ headers = {
 
 conn.request("POST", "/api/v2/users", payload, headers)
 
+## create the directory for the user with podman exec
+subprocess.run(["podman", "exec", "sftpgo", "mkdir", "/srv/sftpgo/data/"+str(NextFpmPort)])

--- a/imageroot/actions/destroy-vhost/validate-input.json
+++ b/imageroot/actions/destroy-vhost/validate-input.json
@@ -33,6 +33,5 @@
             "title": "port",
             "description": "The port of the phpfpm pool"
         }
-        }
     }
 }

--- a/imageroot/actions/update-vhost/validate-input.json
+++ b/imageroot/actions/update-vhost/validate-input.json
@@ -19,7 +19,8 @@
             "lets_encrypt": false,
             "http2https": true,
             "Indexes": "disabled",
-            "status": "enabled"
+            "status": "enabled",
+            "Port": 9001
         }
     ],
     "type": "object",
@@ -35,7 +36,8 @@
         "MaxExecutionTime",
         "MaxFileUploads",
         "Indexes",
-        "status"
+        "status",
+        "Port"
     ],
     "properties": {
         "ServerNames": {
@@ -115,6 +117,12 @@
             "type": "boolean",
             "title": "HTTP to HTTPS redirection",
             "description": "Redirect all the HTTP requests to HTTPS"
+        },
+        "port": {
+            "type": "integer",
+            "minimum": 9001,
+            "title": "port",
+            "description": "The port of the phpfpm pool"
         }
     }
 }

--- a/tests/webserver.robot
+++ b/tests/webserver.robot
@@ -12,8 +12,13 @@ Backend URL is reachable
     ...    return_rc=True  return_stdout=False
     Should Be Equal As Integers    ${rc}  0
 
-VirtualHost URL is reachable
-    ${rc} =    Execute Command    curl -f ${backend_url}
+VirtualHost foo.com URL is reachable
+    ${rc} =    Execute Command    curl -H "Host: foo.com" -f ${backend_url}
+    ...    return_rc=True  return_stdout=False
+    Should Be Equal As Integers    ${rc}  0
+
+VirtualHost john.com URL is reachable
+    ${rc} =    Execute Command    curl -H "Host: john.com" -f ${backend_url}
     ...    return_rc=True  return_stdout=False
     Should Be Equal As Integers    ${rc}  0
 
@@ -38,23 +43,31 @@ Retrieve webserver backend URL
 Check if webserver works as expected
     Retry test    Backend URL is reachable
 
-Check if vhost can be created
-    ${rc} =    Execute Command    api-cli run module/${module_id}/create-vhost --data '{"PhpVersion":"8.2","ServerNames":["foo.com","john.com"],"MemoryLimit":512,"AllowUrlfOpen":"enabled","UploadMaxFilesize":4,"PostMaxSize":8,"MaxExecutionTime":0,"MaxFileUploads":20,"lets_encrypt":false,"http2https":true,"Indexes":"enabled","status":"enabled"}'
+Check if vhost 9001 can be created
+    ${rc} =    Execute Command    api-cli run module/${module_id}/create-vhost --data '{"PhpVersion":"8.2","ServerNames":["foo.com"],"MemoryLimit":512,"AllowUrlfOpen":"disabled","UploadMaxFilesize":4,"PostMaxSize":8,"MaxExecutionTime":0,"MaxFileUploads":20,"lets_encrypt":false,"http2https":false,"Indexes":"disabled","status":"enabled"}'
     ...    return_rc=True  return_stdout=False
     Should Be Equal As Integers    ${rc}  0
 
-Check if vhost can be updated
-    ${rc} =    Execute Command    api-cli run module/${module_id}/update-vhost --data '{"PhpVersion":"8.2","ServerNames":["foo.com","john.com"],"Port":9001,"MemoryLimit":512,"AllowUrlfOpen":"enabled","UploadMaxFilesize":4,"PostMaxSize":8,"MaxExecutionTime":0,"MaxFileUploads":20,"lets_encrypt":false,"http2https":true,"Indexes":"enabled","status":"enabled"}'
+Check if vhost 9001 can be updated
+    ${rc} =    Execute Command    api-cli run module/${module_id}/update-vhost --data '{"PhpVersion":"8.2","ServerNames":["foo.com","john.com"],"Port":9001,"MemoryLimit":1024,"AllowUrlfOpen":"enabled","UploadMaxFilesize":8,"PostMaxSize":16,"MaxExecutionTime":100,"MaxFileUploads":40,"lets_encrypt":true,"http2https":true,"Indexes":"enabled","status":"enabled"}'
     ...    return_rc=True  return_stdout=False
     Should Be Equal As Integers    ${rc}  0
 
-Retrieve virtualhost backend URL
+Retrieve virtualhost foo.com backend URL
     # Assuming the test is running on a single node cluster
     ${response} =    Run task     module/traefik1/get-route    {"instance":"${module_id}-foo.com"}
     Set Suite Variable    ${backend_url}    ${response['url']}
 
-Check if virtualhost works as expected
-    Retry test    VirtualHost URL is reachable
+Check if virtualhost foo.com works as expected
+    Retry test    VirtualHost foo.com URL is reachable
+
+Retrieve virtualhost john.com backend URL
+    # Assuming the test is running on a single node cluster
+    ${response} =    Run task     module/traefik1/get-route    {"instance":"${module_id}-john.com"}
+    Set Suite Variable    ${backend_url}    ${response['url']}
+
+Check if virtualhost john.com works as expected
+    Retry test    VirtualHost john.com URL is reachable
 
 Check if vhost can be destroyed
     ${rc} =    Execute Command    api-cli run module/${module_id}/destroy-vhost --data '{"ServerNames": ["foo.com","john.com"],"port": 9001}'

--- a/tests/webserver.robot
+++ b/tests/webserver.robot
@@ -12,6 +12,10 @@ Backend URL is reachable
     ...    return_rc=True  return_stdout=False
     Should Be Equal As Integers    ${rc}  0
 
+VirtualHost URL is reachable
+    ${rc} =    Execute Command    curl -f ${backend_url}
+    ...    return_rc=True  return_stdout=False
+    Should Be Equal As Integers    ${rc}  0
 
 *** Test Cases ***
 Check if webserver is installed correctly
@@ -43,6 +47,14 @@ Check if vhost can be updated
     ${rc} =    Execute Command    api-cli run module/${module_id}/update-vhost --data '{"PhpVersion":"8.2","ServerNames":["foo.com","john.com"],"Port":9001,"MemoryLimit":512,"AllowUrlfOpen":"enabled","UploadMaxFilesize":4,"PostMaxSize":8,"MaxExecutionTime":0,"MaxFileUploads":20,"lets_encrypt":false,"http2https":true,"Indexes":"enabled","status":"enabled"}'
     ...    return_rc=True  return_stdout=False
     Should Be Equal As Integers    ${rc}  0
+
+Retrieve virtualhost backend URL
+    # Assuming the test is running on a single node cluster
+    ${response} =    Run task     module/traefik1/get-route    {"instance":"${module_id}-foo.com"}
+    Set Suite Variable    ${backend_url}    ${response['url']}
+
+Check if virtualhost works as expected
+    Retry test    VirtualHost URL is reachable
 
 Check if vhost can be destroyed
     ${rc} =    Execute Command    api-cli run module/${module_id}/destroy-vhost --data '{"ServerNames": ["foo.com","john.com"],"port": 9001}'


### PR DESCRIPTION
When you create a virtualhost the folder is not created and when you try to reach the URL nginx gives back a 404 until you go to sftpgo to upload some files in the folder (here 9001). 

this is a bug because a 404 is unexpected, a 403 could be better understood

with my my PR nginx gives a 403 until you allow the root files indexing to allow to browse the files

This PR is also needed to finish the full test of the module, now we can after the virtualhost creation to test the vhost is reachable after the creation-vhost and the update-vhost action


the two fixes below are in the json schema of create-vhost and update vhost


This pull request adds a new "port" configuration option to the validate-input.json file in the imageroot/actions/update-vhost directory. The "port" option allows specifying the port of the phpfpm pool. 

Additionally, unused code has been removed from the validate-input.json file in the imageroot/actions/destroy-vhost directory.


https://github.com/NethServer/dev/issues/6925
