### PR TITLE
Restoration Error Due to Misconfigured Environment Variables

### DIFF
--- a/imageroot/actions/configure-module/20traefik
+++ b/imageroot/actions/configure-module/20traefik
@@ -41,10 +41,6 @@ h2hs = data.get("http2https", True)
 agent.set_env("TRAEFIK_PATH", path)
 agent.set_env("TRAEFIK_HTTP2HTTPS", h2hs)
 
-# Make sure everything is saved inside the environment file
-# just before starting systemd unit
-agent.dump_env()
-
 # Find default traefik instance for current node
 default_traefik_id = agent.resolve_agent_id('traefik@node')
 if default_traefik_id is None:

--- a/imageroot/actions/create-module/10configure
+++ b/imageroot/actions/create-module/10configure
@@ -42,7 +42,3 @@ nginx_tcp_port = env_tcp_ports[1]
 # Setup configuration from user input.
 agent.set_env("SFTPGO_TCP_PORT", sftpgo_tcp_port)
 agent.set_env("NGINX_TCP_PORT", nginx_tcp_port)
-
-# Make sure everything is saved inside the environment file
-# just before starting systemd unit
-agent.dump_env()

--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -35,5 +35,3 @@ for evar in [
         "SFTPGO_SERVICE",
     ]:
     agent.set_env(evar, original_environment[evar])
-
-agent.dump_env()

--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -31,18 +31,8 @@ original_environment = request['environment']
 for evar in [
         "TRAEFIK_PATH",
         "TRAEFIK_HTTP2HTTPS",
+        "SFTP_TCP_PORT",
     ]:
     agent.set_env(evar, original_environment[evar])
-
-# sftp uses the first one, sftpgo uses the second random port, nginx the third one
-env_tcp_ports = os.environ["TCP_PORTS"].split(',')
-sftp_tcp_port = env_tcp_ports[0]
-sftpgo_tcp_port = env_tcp_ports[1]
-nginx_tcp_port = env_tcp_ports[2]
-# Talk with agent using file descriptor.
-# Setup configuration from user input.
-agent.set_env("SFTP_TCP_PORT", sftp_tcp_port)
-agent.set_env("SFTPGO_TCP_PORT", sftpgo_tcp_port)
-agent.set_env("NGINX_TCP_PORT", nginx_tcp_port)
 
 agent.dump_env()

--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -32,6 +32,7 @@ for evar in [
         "TRAEFIK_PATH",
         "TRAEFIK_HTTP2HTTPS",
         "SFTP_TCP_PORT",
+        "SFTPGO_SERVICE",
     ]:
     agent.set_env(evar, original_environment[evar])
 


### PR DESCRIPTION
An error occurred during the restoration because an environment variable related to the SFTPGo configuration was improperly handled, causing it to be out of range. This issue disrupted the restoration, leading to incorrect settings, such as the external SFTPGo access toggle being disabled despite being enabled before the backup. Proper handling of environment variables is essential to ensure all settings are restored accurately.


https://github.com/NethServer/dev/issues/6995