### PR TITLE
Add regex managers and package rules to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>NethServer/.github:ns8"]
+  "extends": ["local>NethServer/.github:ns8"],
+  "regexManagers": [
+    {
+      "fileMatch": ["imageroot/bin/download-php-fpm"],
+      "matchStrings": ["(?<=version_map[8.3]=)d+.d+.d+"],
+      "depNameTemplate": "bitnami/php-fpm",
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["bitnami/php-fpm"],
+      "allowedVersions": "< 8.4.0"
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds regex managers and package rules to the `renovate.json` file. The regex managers are used to match specific strings in the `imageroot/bin/download-php-fpm` file and extract version numbers. The extracted version numbers are then used to set the dependency name and datasource for the `bitnami/php-fpm` package. The package rules specify that only versions lower than `8.4.0` are allowed for the `bitnami/php-fpm` package.