### PR TITLE
Update PHP, sftpgo and nginx versions

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -30,7 +30,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=node:fwadm traefik@node:routeadm" \
     --label="org.nethserver.tcp-ports-demand=2" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/nginx:1.25.4-alpine docker.io/drakkan/sftpgo:v2.5.6-alpine" \
+    --label="org.nethserver.images=docker.io/nginx:1.26.2-alpine docker.io/drakkan/sftpgo:v2.6.2-alpine" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/imageroot/bin/download-php-fpm
+++ b/imageroot/bin/download-php-fpm
@@ -13,9 +13,9 @@ declare -A version_map
 
 version_map[7.4]=7.4.33
 version_map[8.0]=8.0.30
-version_map[8.1]=8.1.27
-version_map[8.2]=8.2.17
-version_map[8.3]=8.3.4
+version_map[8.1]=8.1.30
+version_map[8.2]=8.2.25
+version_map[8.3]=8.3.13
 # Check if major_version is mapped properly
 if [[ -z "${version_map[$minor_version]}" ]]; then
     echo "PHP version $minor_version is not supported" 1>&2


### PR DESCRIPTION
This pull request updates the PHP and nginx versions in the project. The PHP version mappings have been updated to include the latest versions (8.1.30, 8.2.25, and 8.3.13). Similarly, the nginx version has been updated to 1.26.2-alpine and sftpgo to v2.6.2. 


https://github.com/NethServer/dev/issues/7083


why to upgrade

nginx is eol, lets go to stable
sftpgo gets a new UI, we do not have the limit anymore of 30 files
php get new updates