### PR TITLE
Fix PHP-FPM reload command in vhost actions

### DIFF
--- a/imageroot/actions/destroy-vhost/30restart_services
+++ b/imageroot/actions/destroy-vhost/30restart_services
@@ -37,4 +37,4 @@ for folder in PhpServiceArray:
         subprocess.run(["systemctl", "--user", "disable","--now", "phpfpm@"+ConfiguredServices[0].replace('php','')+".service"])
 
 # reload the containers
-subprocess.run(["systemctl", "--user", "reload", "phpfpm@\*.service"])
+subprocess.run(["systemctl", "--user", "reload", "phpfpm@*.service"])

--- a/imageroot/actions/update-vhost/30SystemdServices
+++ b/imageroot/actions/update-vhost/30SystemdServices
@@ -51,7 +51,7 @@ if PhpVersion:
     subprocess.run(["download-php-fpm",str(PhpVersion)])
     # start the container  if stopped
     subprocess.run(["systemctl", "--user", "enable", "--now", "phpfpm@"+str(PhpVersion)+".service"])
-    subprocess.run(["systemctl", "--user", "reload", "phpfpm@\*.service"])
+    subprocess.run(["systemctl", "--user", "reload", "phpfpm@*.service"])
 else:
     subprocess.run(["systemctl", "--user", "reload", "nginx.service"])
-    subprocess.run(["systemctl", "--user", "reload", "phpfpm@\*.service"])
+    subprocess.run(["systemctl", "--user", "reload", "phpfpm@*.service"])


### PR DESCRIPTION
Correct the reload command for PHP-FPM in both destroy and update vhost actions to ensure proper service management.


https://github.com/NethServer/dev/issues/7194