### PR TITLE
Reload PHP-FPM services after configuration changes and update NextFpmPort script

### DIFF
--- a/imageroot/actions/create-vhost/30SystemdServices
+++ b/imageroot/actions/create-vhost/30SystemdServices
@@ -39,6 +39,8 @@ if PhpVersion:
     subprocess.run(["download-php-fpm",str(PhpVersion)])
     # start the container  if stopped
     subprocess.run(["systemctl", "--user", "enable", "--now", "phpfpm@"+str(PhpVersion)+".service"])
+    # we need to reload the php fpm service to let him know about the new configuration
+    subprocess.run(["systemctl", "--user", "reload", "phpfpm@"+str(PhpVersion)+".service"])
 else:
     subprocess.run(["systemctl", "--user", "reload", "nginx.service"])
 

--- a/imageroot/actions/update-vhost/30SystemdServices
+++ b/imageroot/actions/update-vhost/30SystemdServices
@@ -51,6 +51,7 @@ if PhpVersion:
     subprocess.run(["download-php-fpm",str(PhpVersion)])
     # start the container  if stopped
     subprocess.run(["systemctl", "--user", "enable", "--now", "phpfpm@"+str(PhpVersion)+".service"])
+    # php version might have changed, reload all php-fpm services
     subprocess.run(["systemctl", "--user", "reload", "phpfpm@*.service"])
 else:
     subprocess.run(["systemctl", "--user", "reload", "nginx.service"])

--- a/imageroot/update-module.d/10fix_NextFpmPort
+++ b/imageroot/update-module.d/10fix_NextFpmPort
@@ -61,6 +61,6 @@ with open(output_file, "r") as f:
 if current_id is None or last_id > current_id:
     with open(output_file, "w") as f:
         f.write(str(last_id))
-    print(f"Last {os.environ['MODULE_ID']} virtualhost ID {last_id} written to {output_file}", file=sys.stderr)
+    print(f"{os.environ['MODULE_ID']}: Last virtualhost ID {last_id} written to {output_file}", file=sys.stderr)
 else:
-    print(f"Last {os.environ['MODULE_ID']} virtualhost ID {last_id} not written. Current ID in file: {current_id}", file=sys.stderr)
+    print(f"{os.environ['MODULE_ID']}: Last virtualhost ID {last_id} not written, the current ID {current_id} in {output_file} is good", file=sys.stderr)

--- a/imageroot/update-module.d/10fix_NextFpmPort
+++ b/imageroot/update-module.d/10fix_NextFpmPort
@@ -45,7 +45,7 @@ try:
     if ids:
         last_id = max(ids)
     else:
-        last_id = 10000  # Default to 10 000 if no IDs exist few chances to get 1000 active vhosts
+        last_id = 0  # Default to 0 if no IDs exist, no vhosts
 except:
     last_id = 10000  # Default to 10 000 if ecxeption, few chances to get 1000 active vhosts
 

--- a/imageroot/update-module.d/10fix_NextFpmPort
+++ b/imageroot/update-module.d/10fix_NextFpmPort
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# first release where buildt with a static file NextFpmPort set to 9000
+# during upgrade the value of virtualhost ID was overwritten with the default value 9000
+# this script will attempt to discover how many configuration we have 
+# and set the NextFpmPort file accordingly
+
+# Todo: NextFpmPort should be named LastFpmPort (when the vhost is created, the last ID is written there)
+
+# actions:
+# find all existing ID of vhosts
+# keep the max value or default to 10 000 if no vhosts are found or exception (probably a module never used, but be prudent)
+# read the NextFpmPort file
+# if current_id is None or last_id > current_id write the last_id to the file
+
+
+import os
+import re
+import sys
+
+# Define the directory and the target file
+directory = "databases/vhosts/"
+output_file = "databases/NextFpmPort"
+
+# Find all .ini files
+ini_files = [f for f in os.listdir(directory) if f.endswith('.ini')]
+
+# Extract IDs from filenames
+ids = []
+try:
+    for file in ini_files:
+        # we want to match 9001.ini and retrieve 9001
+        match = re.match(r"(\d+)\.ini", file)
+        if match:
+            ids.append(int(match.group(1)))
+
+    # Determine the last ID
+    if ids:
+        last_id = max(ids)
+    else:
+        last_id = 10000  # Default to 10 000 if no IDs exist few chances to get 1000 active vhosts
+except:
+    last_id = 10000  # Default to 10 000 if ecxeption, few chances to get 1000 active vhosts
+
+# Read the current value from the NextFpmPort file if it exists
+current_id = None
+if os.path.exists(output_file):
+    with open(output_file, "r") as f:
+        try:
+            current_id = int(f.read().strip())
+        except ValueError:
+            current_id = None
+
+# Write the last ID only if it's greater than the current value
+if current_id is None or last_id > current_id:
+    with open(output_file, "w") as f:
+        f.write(str(last_id))
+    print(f"Last {os.environ['MODULE_ID']} virtualhost ID {last_id} written to {output_file}", file=sys.stderr)
+else:
+    print(f"Last {os.environ['MODULE_ID']} virtualhost ID {last_id} not written. Current ID in file: {current_id}", file=sys.stderr)

--- a/imageroot/update-module.d/10fix_NextFpmPort
+++ b/imageroot/update-module.d/10fix_NextFpmPort
@@ -7,9 +7,9 @@
 
 # first release where buildt with a static file NextFpmPort set to 9000
 # during upgrade the value of virtualhost ID was overwritten with the default value 9000
-# this script will attempt to discover how many configuration we have 
+# this script will attempt to discover how many configurations we have 
 # and set the NextFpmPort file accordingly
-
+# Added with the release 1.0.20
 # Todo: NextFpmPort should be named LastFpmPort (when the vhost is created, the last ID is written there)
 
 # actions:
@@ -27,7 +27,7 @@ import sys
 directory = "databases/vhosts/"
 output_file = "databases/NextFpmPort"
 
-# no vhosts, no need to continue
+# no NextFpmPort, no need to continue
 if not os.path.exists(output_file):
     sys.exit(0)
 

--- a/imageroot/update-module.d/10fix_NextFpmPort
+++ b/imageroot/update-module.d/10fix_NextFpmPort
@@ -27,6 +27,10 @@ import sys
 directory = "databases/vhosts/"
 output_file = "databases/NextFpmPort"
 
+# no vhosts, no need to continue
+if not os.path.exists(output_file):
+    sys.exit(0)
+
 # Find all .ini files
 ini_files = [f for f in os.listdir(directory) if f.endswith('.ini')]
 
@@ -49,12 +53,11 @@ except:
 
 # Read the current value from the NextFpmPort file if it exists
 current_id = None
-if os.path.exists(output_file):
-    with open(output_file, "r") as f:
-        try:
-            current_id = int(f.read().strip())
-        except ValueError:
-            current_id = None
+with open(output_file, "r") as f:
+    try:
+        current_id = int(f.read().strip())
+    except ValueError:
+        current_id = None
 
 # Write the last ID only if it's greater than the current value
 if current_id is None or last_id > current_id:

--- a/imageroot/update-module.d/10fix_NextFpmPort
+++ b/imageroot/update-module.d/10fix_NextFpmPort
@@ -20,7 +20,6 @@
 
 
 import os
-import re
 import sys
 
 # Define the directory and the target file
@@ -38,10 +37,9 @@ ini_files = [f for f in os.listdir(directory) if f.endswith('.ini')]
 ids = []
 try:
     for file in ini_files:
-        # we want to match 9001.ini and retrieve 9001
-        match = re.match(r"(\d+)\.ini", file)
-        if match:
-            ids.append(int(match.group(1)))
+        # Remove the .ini suffix and convert the remaining part to an integer
+        id_str = file.removesuffix(".ini")
+        ids.append(int(id_str))
 
     # Determine the last ID
     if ids:

--- a/imageroot/update-module.d/10fix_NextFpmPort
+++ b/imageroot/update-module.d/10fix_NextFpmPort
@@ -63,4 +63,4 @@ if current_id is None or last_id > current_id:
         f.write(str(last_id))
     print(f"{os.environ['MODULE_ID']}: Last virtualhost ID {last_id} written to {output_file}", file=sys.stderr)
 else:
-    print(f"{os.environ['MODULE_ID']}: Last virtualhost ID {last_id} not written, the current ID {current_id} in {output_file} is good", file=sys.stderr)
+    print(f"{os.environ['MODULE_ID']}: Last virtualhost ID {last_id} not written, the current ID {current_id} in {output_file} is correct", file=sys.stderr)


### PR DESCRIPTION
Ensure PHP-FPM services reload when configurations change or PHP versions are updated. Introduce a script to dynamically set the NextFpmPort based on existing virtual host IDs.

https://github.com/NethServer/dev/issues/7200