### PR TITLE
fix(sftpgo): set owner of root folder to sftpgo user

### DIFF
--- a/imageroot/actions/create-vhost/10base
+++ b/imageroot/actions/create-vhost/10base
@@ -96,6 +96,4 @@ headers = {
 conn.request("POST", "/api/v2/users", payload, headers)
 
 ## create the directory for the user with podman exec
-subprocess.run(["podman", "exec", "sftpgo", "mkdir", "/srv/sftpgo/data/"+str(NextFpmPort)])
-# change owner of the root folder to bin:9001 for example
-subprocess.run(["podman", "exec", "sftpgo", "chown", "bin:"+str(NextFpmPort), "/srv/sftpgo/data/"+str(NextFpmPort)])
+subprocess.run(["podman", "exec", "sftpgo", "install", "-d", "-m", "0755", "-o", "bin", "-g", "root", "/srv/sftpgo/data/"+str(NextFpmPort)])

--- a/imageroot/actions/create-vhost/10base
+++ b/imageroot/actions/create-vhost/10base
@@ -97,3 +97,5 @@ conn.request("POST", "/api/v2/users", payload, headers)
 
 ## create the directory for the user with podman exec
 subprocess.run(["podman", "exec", "sftpgo", "mkdir", "/srv/sftpgo/data/"+str(NextFpmPort)])
+# change owner of the root folder to bin:9001 for example
+subprocess.run(["podman", "exec", "sftpgo", "chown", "bin:"+str(NextFpmPort), "/srv/sftpgo/data/"+str(NextFpmPort)])


### PR DESCRIPTION
The user of sftpgo is not used, some webapps like joomla complains about a lack of permission

see https://community.nethserver.org/t/rsync-to-virtual-host/25226


![image](https://github.com/user-attachments/assets/50e1e9fa-5bf6-4630-bdbc-8b6a424d2dac)


doing a chmod is needed to fix it 

/var/lib/sftpgo # chown bin:9002 /srv/sftpgo/data/9002/
