### PR TITLE
Add cron support to sftpgo container and update backup configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,28 @@ We use local database to store configuration, you can find it `/home/webserver1/
 - add `dyn-9001.custom` to  `/home/webserver1/.config/state/php{php version}-fpm-custom.d/` for example `/home/webserver1/.config/state/php7.4-fpm-custom.d/`
 - `vim /home/webserver1/.config/state/php7.4-fpm-custom.d/dyn-9001.custom` and write a valid php-fpm configuration
 - set the file ownership to webserver1 : `chown webserver1:webserver1 /home/webserver1/.config/state/php7.4-fpm-custom.d/dyn-9001.custom`
-  
+
+#
+# Cron in sftpgo container
+#
+
+You can use a cron inside the sftpgo container. You must be compatible with a cron format. You can do it by using this command line:
+`runagent -m mail1`
+`podman exec -ti sftpgo crontab -e`
+
+```
+* * * * * command_to_execute
+- - - - -
+| | | | |
+| | | | +---- Day of the week (0 - 7, Sunday is 0 or 7)
+| | | +------ Month (1 - 12)
+| | +-------- Day of the month (1 - 31)
+| +---------- Hour (0 - 23)
++------------ Minute (0 - 59)
+```
+
+you can verify the cron by `podman exec -ti sftpgo crontab -l`
+
 ## sftpgo : push the website
 
  Sftpgo is used to upload files to the webserver, once the webserver module is installed the default password and user are admin:admin at http://foo.com/sftpgo/, think to change it

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -13,3 +13,4 @@ state/sftpgo.conf.d/API_KEY
 # we only backup custom, conf are expanded
 state/conf.d/*.custom
 state/php*-fpm-custom.d/*.custom
+state/crontabs

--- a/imageroot/systemd/user/sftpgo.service
+++ b/imageroot/systemd/user/sftpgo.service
@@ -8,6 +8,7 @@ EnvironmentFile=%S/state/environment
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70
+ExecStartPre=/bin/mkdir -vp crontabs
 ExecStartPre=/bin/rm -f %t/sftpgo.pid %t/sftpgo.ctr-id
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/sftpgo.pid \
     --cidfile %t/sftpgo.ctr-id --cgroups=no-conmon \
@@ -15,12 +16,15 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/sftpgo.pid \
     --volume websites:/srv/sftpgo/data:z \
     --volume sftpgo_backups:/srv/sftpgo/backups:Z \
     --volume sftpgo_config:/var/lib/sftpgo:Z \
+    --volume ./crontabs:/var/spool/cron/crontabs:Z \
     --volume %S/state/sftpgo.conf.d/admin.json:/etc/sftpgo/admin.json:Z \
     --env SFTPGO_LOADDATA_FROM=/etc/sftpgo/admin.json \
     --env SFTPGO_HTTPD__WEB_ROOT=${TRAEFIK_PATH}\
     --user 0:0 \
     ${SFTPGO_IMAGE}
 ExecStartPost=/usr/bin/bash -c "while [[ $(curl --request GET --url http://localhost:${SFTPGO_TCP_PORT}/healthz --header 'Accept: text/plain; charset=utf-8') != ok ]]; do sleep 3 ; done"
+# start crond inside 
+ExecStartPost=podman exec sftpgo crond -L 2
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/sftpgo.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/sftpgo.ctr-id
 PIDFile=%t/sftpgo.pid

--- a/imageroot/systemd/user/sftpgo.service
+++ b/imageroot/systemd/user/sftpgo.service
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/sftpgo.pid \
     --volume %S/state/sftpgo.conf.d/admin.json:/etc/sftpgo/admin.json:Z \
     --env SFTPGO_LOADDATA_FROM=/etc/sftpgo/admin.json \
     --env SFTPGO_HTTPD__WEB_ROOT=${TRAEFIK_PATH}\
+    --env SFTPGO_SFTPD__ENABLED_SSH_COMMANDS=rsync \
     --user 0:0 \
     ${SFTPGO_IMAGE}
 ExecStartPost=/usr/bin/bash -c "while [[ $(curl --request GET --url http://localhost:${SFTPGO_TCP_PORT}/healthz --header 'Accept: text/plain; charset=utf-8') != ok ]]; do sleep 3 ; done"


### PR DESCRIPTION
Include crontabs in the backup configuration, update the sftpgo service to create a crontabs directory and start the cron daemon, and add documentation for using cron within the sftpgo container. Additionally, enable rsync SSH commands in the sftpgo service configuration.