### PR TITLE
Add PHP 8.4 support across documentation and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ Send a test HTTP request to the webserver backend service:
 
 a vhost can be created by the api-cli command
 
-We use a container with nginx and another container for the php-fpm configuration (actually availlable PHP 7.4,8.0,8.1,8.2,8.3)
+We use a container with nginx and another container for the php-fpm configuration (actually availlable PHP 7.4,8.0,8.1,8.2,8.3,8.4)
 
 Launch `create-vhost`, by setting the following parameters:
-- `PhpVersion`: Set the version of php needed, can be `''(no php), 7.4,8.0,8.1,8.2,8.3`
+- `PhpVersion`: Set the version of php needed, can be `''(no php), 7.4,8.0,8.1,8.2,8.3,8.4`
 - `ServerNames`: set the domain name of the vhost, it must be an array
 - `MemoryLimit`: This sets the maximum amount of memory that a script is allowed to allocate. use `MB`
 - `AllowUrlfOpen` : This option enables the URL-aware fopen wrappers that enable accessing URL object like files. use `enabled|disabled`
@@ -223,7 +223,7 @@ The TCP port of the php-fpm port is unique, each virtualhost gets a nex tcp port
 
 Launch `update-vhost`, by setting the following parameters:
 - `port`: The tcp port of php-fpm, it is used as an ID for the virtualhost
-- `PhpVersion`: Set the version of php needed, can be `''(no php), 7.4,8.0,8.1,8.2,8.3`
+- `PhpVersion`: Set the version of php needed, can be `''(no php), 7.4,8.0,8.1,8.2,8.3,8.4`
 - `ServerNames`: set the domain name of the vhost, it must be an array
 - `MemoryLimit`: This sets the maximum amount of memory that a script is allowed to allocate. use `MB`
 - `AllowUrlfOpen` : This option enables the URL-aware fopen wrappers that enable accessing URL object like files. use `enabled|disabled`

--- a/imageroot/actions/create-vhost/validate-input.json
+++ b/imageroot/actions/create-vhost/validate-input.json
@@ -53,7 +53,7 @@
             "format": "regex",
             "pattern":"(^[0-9][.][0-9]$|^$)",
             "title": "PhpVersion",
-            "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or 8.3 or ''"
+            "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or 8.3 or 8.4 or ''"
         },
         "MemoryLimit": {
             "type": "integer",

--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -102,7 +102,7 @@
                         "format": "regex",
                         "pattern": "(^[0-9][.][0-9]$|^$)",
                         "title": "PhpVersion",
-                        "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or 8.3 or ''"
+                        "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or 8.3 or 8.4 or ''"
                     },
                     "MemoryLimit": {
                         "type": "integer",

--- a/imageroot/actions/update-vhost/validate-input.json
+++ b/imageroot/actions/update-vhost/validate-input.json
@@ -55,7 +55,7 @@
             "format": "regex",
             "pattern": "(^[0-9][.][0-9]$|^$)",
             "title": "PhpVersion",
-            "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or 8.3 or ''"
+            "description": "Could be 7.4 or 8.0 or 8.1 or 8.2 or 8.3 or 8.4 or ''"
         },
         "MemoryLimit": {
             "type": "integer",

--- a/imageroot/bin/download-php-fpm
+++ b/imageroot/bin/download-php-fpm
@@ -16,6 +16,7 @@ version_map[8.0]=8.0.30
 version_map[8.1]=8.1.31
 version_map[8.2]=8.2.26
 version_map[8.3]=8.3.14
+version_map[8.4]=8.4.6
 # Check if major_version is mapped properly
 if [[ -z "${version_map[$minor_version]}" ]]; then
     echo "PHP version $minor_version is not supported" 1>&2

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -50,6 +50,7 @@
     "PHP_81":"PHP 8.1",
     "PHP_82":"PHP 8.2",
     "PHP_83":"PHP 8.3",
+    "PHP_84":"PHP 8.4",
     "container_version_will_be_installed":"Changing PHP version will install a new PHP container: configuration might take a while",
     "select_php_version":"Version of PHP",
     "AllowUrlfOpen":"URL-aware fopen wrappers",

--- a/ui/src/views/VirtualHosts.vue
+++ b/ui/src/views/VirtualHosts.vue
@@ -264,6 +264,9 @@
             <cv-dropdown-item value="8.3">{{
               $t("virtualhosts.PHP_83")
             }}</cv-dropdown-item>
+            <cv-dropdown-item value="8.4">{{
+              $t("virtualhosts.PHP_84")
+            }}</cv-dropdown-item>
           </cv-dropdown>
           <!-- advanced options -->
           <cv-accordion ref="accordion">


### PR DESCRIPTION
Update the README and various schema files to include PHP 8.4 as an available version, ensuring consistency in dropdowns and validation descriptions.
