### PR TITLE
Updates the version used for nginx and php 8.4

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -30,7 +30,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=node:fwadm traefik@node:routeadm" \
     --label="org.nethserver.tcp-ports-demand=2" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/nginx:1.27.5-alpine docker.io/drakkan/sftpgo:v2.6.6-alpine" \
+    --label="org.nethserver.images=docker.io/nginx:1.28.0-alpine docker.io/drakkan/sftpgo:v2.6.6-alpine" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/imageroot/bin/download-php-fpm
+++ b/imageroot/bin/download-php-fpm
@@ -16,7 +16,7 @@ version_map[8.0]=8.0.30
 version_map[8.1]=8.1.31
 version_map[8.2]=8.2.26
 version_map[8.3]=8.3.14
-version_map[8.4]=8.4.6
+version_map[8.4]=8.4.11
 # Check if major_version is mapped properly
 if [[ -z "${version_map[$minor_version]}" ]]; then
     echo "PHP version $minor_version is not supported" 1>&2


### PR DESCRIPTION
This pull request updates the base image version used for `nginx` and php 8.4 in the build process to ensure the latest features and security patches are included.

Dependency update:

* Updated the `org.nethserver.images` label in `build-images.sh` to reference `docker.io/nginx:1.28.0-alpine` instead of `1.27.5-alpine`
* upgrade php-fpm to 8.4.11

https://github.com/NethServer/dev/issues/7589