### PR TITLE
php-fpm: change upstream image to php project

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -10,6 +10,60 @@ repobase="${REPOBASE:-ghcr.io/nethserver}"
 # Configure the image name
 reponame="webserver"
 
+podman build \
+    --force-rm \
+    --layers \
+    --tag "${repobase}/php8.4-fpm" \
+    --build-arg "PHP_VERSION=docker.io/library/php:8.4.11-fpm" \
+    container
+
+images+=("${repobase}/php8.4-fpm")
+
+podman build \
+    --force-rm \
+    --layers \
+    --tag "${repobase}/php8.3-fpm" \
+    --build-arg "PHP_VERSION=docker.io/library/php:8.3.4-fpm" \
+    container
+
+images+=("${repobase}/php8.3-fpm")
+
+podman build \
+    --force-rm \
+    --layers \
+    --tag "${repobase}/php8.2-fpm" \
+    --build-arg "PHP_VERSION=docker.io/library/php:8.2.29-fpm" \
+    container
+
+images+=("${repobase}/php8.2-fpm")
+
+podman build \
+    --force-rm \
+    --layers \
+    --tag "${repobase}/php8.1-fpm" \
+    --build-arg "PHP_VERSION=docker.io/library/php:8.1.33-fpm" \
+    container
+
+images+=("${repobase}/php8.1-fpm")
+
+podman build \
+    --force-rm \
+    --layers \
+    --tag "${repobase}/php8.0-fpm" \
+    --build-arg "PHP_VERSION=docker.io/library/php:8.0.30-fpm" \
+    container
+
+images+=("${repobase}/php8.0-fpm")
+
+podman build \
+    --force-rm \
+    --layers \
+    --tag "${repobase}/php7.4-fpm" \
+    --build-arg "PHP_VERSION=docker.io/library/php:7.4.33-fpm" \
+    container
+
+images+=("${repobase}/php7.4-fpm")
+
 # Create a new empty container image
 container=$(buildah from scratch)
 

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,0 +1,67 @@
+ARG PHP_VERSION
+ENV PHP_VERSION=$PHP_VERSION
+
+FROM $PHP_VERSION
+
+# Installation des dépendances nécessaires à la compilation
+RUN apt-get update && apt-get install -y \
+    libzip-dev \
+    libldap2-dev \
+    libtidy-dev \
+    libpng-dev \
+    libjpeg-dev \
+    libwebp-dev \
+    libfreetype6-dev \
+    libicu-dev \
+    libbz2-dev \
+    libssl-dev \
+    libargon2-dev \
+    zlib1g-dev \
+    libgmp-dev \
+    libcurl4-openssl-dev \
+    libsqlite3-dev \
+    libxml2-dev \
+    libpq-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+    && docker-php-ext-install \
+        soap \
+        sockets \
+        tidy \
+        ldap \
+        gd \
+        intl \
+        zip \
+        bcmath \
+        opcache \
+        exif \
+        pdo_mysql \
+        pdo_pgsql \
+        pgsql \
+        mysqli \
+        bz2 \
+        xml \
+    && apt-get purge -y \
+        libzip-dev \
+        libldap2-dev \
+        libtidy-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libwebp-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libbz2-dev \
+        libssl-dev \
+        libargon2-dev \
+        zlib1g-dev \
+        libgmp-dev \
+        libcurl4-openssl-dev \
+        libsqlite3-dev \
+        libxml2-dev \
+        libpq-dev \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/* /var/tmp/*
+
+# copie docker-php-ext-opcache.ini to  /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+COPY docker-php-ext-opcache.ini /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini

--- a/container/docker-php-ext-opcache.ini
+++ b/container/docker-php-ext-opcache.ini
@@ -1,0 +1,1 @@
+zend_extension=opcache

--- a/imageroot/actions/clone-module/60pull-php-image
+++ b/imageroot/actions/clone-module/60pull-php-image
@@ -26,6 +26,6 @@ import re
 PhpServiceArray = glob.glob('php*-fpm-custom.d')
 for folder in PhpServiceArray:
     ConfiguredServices = re.findall('php[0-9\.]+', folder)
-    ListConfigurations = glob.glob(folder+'/*.conf')
+    ListConfigurations = glob.glob(folder+'/dyn-*.conf')
     if ListConfigurations :
         subprocess.run(["download-php-fpm",ConfiguredServices[0].replace('php','')])

--- a/imageroot/actions/destroy-vhost/30restart_services
+++ b/imageroot/actions/destroy-vhost/30restart_services
@@ -32,7 +32,7 @@ subprocess.run(["systemctl", "--user", "reload", "nginx.service"])
 PhpServiceArray = glob.glob('php*-fpm-custom.d')
 for folder in PhpServiceArray:
     ConfiguredServices = re.findall('php[0-9\.]+', folder)
-    ListConfigurations = glob.glob(folder+'/*.conf')
+    ListConfigurations = glob.glob(folder+'/dyn-*.conf')
     if not ListConfigurations :
         subprocess.run(["systemctl", "--user", "disable","--now", "phpfpm@"+ConfiguredServices[0].replace('php','')+".service"])
 

--- a/imageroot/actions/restore-module/60systemd
+++ b/imageroot/actions/restore-module/60systemd
@@ -37,7 +37,7 @@ agent.run_helper("systemctl", "--user", "restart", "sftpgo.service").check_retur
 PhpServiceArray = glob.glob('php*-fpm-custom.d')
 for folder in PhpServiceArray:
     ConfiguredServices = re.findall('php[0-9\.]+', folder)
-    ListConfigurations = glob.glob(folder+'/*.conf')
+    ListConfigurations = glob.glob(folder+'/dyn-*.conf')
     if ListConfigurations :
         subprocess.run(["download-php-fpm",ConfiguredServices[0].replace('php','')])
         subprocess.run(["systemctl", "--user", "enable","--now", "phpfpm@"+ConfiguredServices[0].replace('php','')+".service"])

--- a/imageroot/actions/update-vhost/30SystemdServices
+++ b/imageroot/actions/update-vhost/30SystemdServices
@@ -44,7 +44,7 @@ if PhpVersion:
     PhpServiceArray = glob.glob('php*-fpm-custom.d')
     for folder in PhpServiceArray:
         ConfiguredServices = re.findall('php[0-9\.]+', folder)
-        ListConfigurations = glob.glob(folder+'/*.conf')
+        ListConfigurations = glob.glob(folder+'/dyn-*.conf')
         if not ListConfigurations :
             subprocess.run(["systemctl", "--user", "disable","--now", "phpfpm@"+ConfiguredServices[0].replace('php','')+".service"])
     # pull the image if missing

--- a/imageroot/bin/download-php-fpm
+++ b/imageroot/bin/download-php-fpm
@@ -9,22 +9,13 @@ set -e
 
 minor_version="${1:?We expect one argument}"
 
-declare -A version_map
+# retrieve environment IMAGE_URL, remove the registry if present and keep the tag, e.g. `1.1.1`
+image_url="${IMAGE_URL:-? We expect IMAGE_URL environment variable}"
+# remove `ghcr.io/nethserver/webserver:`
+tag="${image_url##*:}"
 
-version_map[7.4]=7.4.33
-version_map[8.0]=8.0.30
-version_map[8.1]=8.1.31
-version_map[8.2]=8.2.26
-version_map[8.3]=8.3.14
-version_map[8.4]=8.4.11
-# Check if major_version is mapped properly
-if [[ -z "${version_map[$minor_version]}" ]]; then
-    echo "PHP version $minor_version is not supported" 1>&2
-    exit 1
-fi
+# save the php tag for later use in the systemd service
+echo "IMAGE_URL_TAG=$tag" > image_url_tag.env
 
 # pull the image
-podman-pull-missing "docker.io/bitnami/php-fpm:${version_map[$minor_version]}"
-# systemd service use docker.io/bitnami/php-fpm:8.1 
-# we need to tag with major version to use it locally
-/usr/bin/podman tag  "docker.io/bitnami/php-fpm:${version_map[$minor_version]}" "docker.io/bitnami/php-fpm:${minor_version}"
+podman-pull-missing "ghcr.io/nethserver/php$minor_version-fpm:$tag"

--- a/imageroot/bin/expand-vhosts
+++ b/imageroot/bin/expand-vhosts
@@ -24,8 +24,7 @@ import os
 import glob
 import configparser
 import json
-import sys
-import subprocess
+import shutil
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 for file in glob.iglob("conf.d/dyn-*.conf"):
@@ -87,3 +86,8 @@ for file in glob.iglob("databases/vhosts/*.ini"):
             f.write(output)
         # php-fpm expects to find its customisation file
         open("php"+str(PhpVersion)+"-fpm-custom.d/dyn-"+str(port)+".custom", "a").close
+        # copy the default configurations
+        shutil.copyfile(
+            os.path.join(os.getenv("AGENT_INSTALL_DIR"), "templates", "docker.conf"),
+            f"php{PhpVersion}-fpm-custom.d/docker.conf"
+        )

--- a/imageroot/systemd/user/phpfpm@.service
+++ b/imageroot/systemd/user/phpfpm@.service
@@ -7,6 +7,7 @@ ConditionDirectoryNotEmpty=%S/state/php%i-fpm-custom.d/
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
+EnvironmentFile=%S/state/image_url_tag.env
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70
@@ -15,8 +16,9 @@ ExecStartPre=/usr/bin/mkdir -p %S/state/php%i-fpm-custom.d
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/php%i-fpm.pid \
     --cidfile %t/php%i-fpm.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/webserver.pod-id --replace -d --name  php%i-fpm \
-    --volume websites:/app:z --volume %S/state/php%i-fpm-custom.d:/opt/bitnami/php/etc/php-fpm.d:Z \
-    docker.io/bitnami/php-fpm:%i
+    --volume websites:/var/www/html:z \
+    --volume %S/state/php%i-fpm-custom.d:/usr/local/etc/php-fpm.d:z \
+    ghcr.io/nethserver/php%i-fpm:${IMAGE_URL_TAG}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/php%i-fpm.ctr-id -t 10
 ExecReload=/usr/bin/mkdir -p %S/state/php%i-fpm-custom.d
 ExecReload=/usr/bin/podman kill -s USR2 php%i-fpm

--- a/imageroot/templates/docker.conf
+++ b/imageroot/templates/docker.conf
@@ -1,0 +1,5 @@
+[global]
+error_log = /proc/self/fd/2
+daemonize = no
+; https://github.com/docker-library/php/pull/725#issuecomment-443540114
+log_limit = 8192

--- a/imageroot/templates/php-fpm-pool.conf
+++ b/imageroot/templates/php-fpm-pool.conf
@@ -7,9 +7,14 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
-include=/opt/bitnami/php/etc/environment.conf
-include=/opt/bitnami/php/etc/common.conf
-include=/opt/bitnami/php/etc/php-fpm.d/dyn-{{port}}.custom
+include=/usr/local/etc/php-fpm.d/dyn-{{port}}.custom
+; php-fpm closes STDOUT on startup, so sending logs to /proc/self/fd/1 does not work.
+; https://bugs.php.net/bug.php?id=73886
+access.log = /proc/self/fd/2
+clear_env = no
+; Ensure worker stdout and stderr are sent to the main error log.
+catch_workers_output = yes
+decorate_workers_output = no
 php_admin_value[memory_limit]={{MemoryLimit}}M
 {% if AllowUrlfOpen == 'disabled' %}
 php_admin_flag[allow_url_fopen]=off

--- a/imageroot/templates/vhost-nginx.conf
+++ b/imageroot/templates/vhost-nginx.conf
@@ -26,7 +26,7 @@ server {
         fastcgi_pass 127.0.0.1:{{port}};
         fastcgi_index index.php;
         include fastcgi_params;
-        fastcgi_param  SCRIPT_FILENAME  /app/{{WebRoot}}$fastcgi_script_name;
+        fastcgi_param  SCRIPT_FILENAME  /var/www/html/{{WebRoot}}$fastcgi_script_name;
     }
 {% endif %}
 }

--- a/imageroot/update-module.d/15clean-php-images
+++ b/imageroot/update-module.d/15clean-php-images
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# We want to remove php images that are not used by any php-fpm containers.
+# We use `podman rmi` to remove images, ignoring errors if they are in use.
+# Images with dual tags will not be removed (they are in use by the php-fpm service)
+
+for img_id in $(podman images --quiet --filter=reference='ghcr.io/nethserver/php*-fpm:*'); do
+    # try to remove the image, ignoring errors if it's in use
+    podman rmi "$img_id" 2>/dev/null
+done
+
+# With the change from bitnami images to official images, we have some old bitnami images (with dual tags)
+# that are not used anymore. We can remove them by filtering with the "bitnami" repository.
+# This is safe because we are sure that the current ns8 module does not use bitnami images.
+# bitnami was used with webserver:1.1.2 and earlier.
+for img_id in $(podman images --quiet --filter=reference='docker.io/bitnami/php-fpm:*'); do
+    podman rmi -f "$img_id"
+done

--- a/imageroot/update-module.d/15clean-php-images
+++ b/imageroot/update-module.d/15clean-php-images
@@ -7,7 +7,6 @@
 
 # We want to remove php images that are not used by any php-fpm containers.
 # We use `podman rmi` to remove images, ignoring errors if they are in use.
-# Images with dual tags will not be removed (they are in use by the php-fpm service)
 
 for img_id in $(podman images --quiet --filter=reference='ghcr.io/nethserver/php*-fpm:*'); do
     # try to remove the image, ignoring errors if it's in use

--- a/imageroot/update-module.d/20restart
+++ b/imageroot/update-module.d/20restart
@@ -34,7 +34,7 @@ agent.run_helper("systemctl", "--user", "try-restart", "sftpgo.service").check_r
 PhpServiceArray = glob.glob('php*-fpm-custom.d')
 for folder in PhpServiceArray:
     ConfiguredServices = re.findall('php[0-9\.]+', folder)
-    ListConfigurations = glob.glob(folder+'/*.conf')
+    ListConfigurations = glob.glob(folder+'/dyn-*.conf')
     if ListConfigurations :
         subprocess.run(["download-php-fpm",ConfiguredServices[0].replace('php','')])
         subprocess.run(["systemctl", "--user", "try-restart", "phpfpm@"+ConfiguredServices[0].replace('php','')+".service"])


### PR DESCRIPTION
This pull request introduces major improvements to the PHP-FPM container images and their integration into the system. It adds automated builds for multiple PHP versions, switches to official PHP images, updates configuration templates for better logging and compatibility, and refines service management logic to ensure only dynamic configurations are considered. Additionally, it provides a cleanup script to remove unused images and updates systemd and nginx integration for correct paths and improved reliability.


https://github.com/NethServer/dev/issues/7610


This version solves some issues we have with the previous version
- we build our version of php (from the php official), bitnami cannot offer us the free version with a tag like before. I have enabled the same php module that I could have found in the bitnami images
https://github.com/NethServer/ns8-webserver/blob/phpOffcial/container/Containerfile
https://github.com/NethServer/ns8-webserver/blob/phpOffcial/container/docker-php-ext-opcache.ini
- we clean the php [images with the upgrade action](https://github.com/NethServer/ns8-webserver/blob/phpOffcial/imageroot/update-module.d/15clean-images), that was not done before
-  With the build we have set the full docker url registry in the build-images.sh, [so renovate should work and warn us about updates](https://github.com/NethServer/ns8-webserver/blob/e802355bbee9cd48840ddedb2cf524f4d52eb657/build-images.sh#L13C22-L13C47)
- I have disabled the unused www default pool
- The new php-fpm configurations I add come from the default configuration we can find for the www default pool in the `docker.io/library/php:*-fpm` containers