### PR TITLE
Update PHP version handling and dependencies for compatibility with Bullseye and Trixie

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -14,7 +14,7 @@ podman build \
     --force-rm \
     --layers \
     --tag "${repobase}/php8.4-fpm" \
-    --build-arg "PHP_VERSION=docker.io/library/php:8.4.11-fpm" \
+    --build-arg "PHP_VERSION_IMAGE=docker.io/library/php:8.4.12-fpm-trixie" \
     container
 
 images+=("${repobase}/php8.4-fpm")
@@ -23,7 +23,7 @@ podman build \
     --force-rm \
     --layers \
     --tag "${repobase}/php8.3-fpm" \
-    --build-arg "PHP_VERSION=docker.io/library/php:8.3.4-fpm" \
+    --build-arg "PHP_VERSION_IMAGE=docker.io/library/php:8.3.25-fpm-trixie" \
     container
 
 images+=("${repobase}/php8.3-fpm")
@@ -32,7 +32,7 @@ podman build \
     --force-rm \
     --layers \
     --tag "${repobase}/php8.2-fpm" \
-    --build-arg "PHP_VERSION=docker.io/library/php:8.2.29-fpm" \
+    --build-arg "PHP_VERSION_IMAGE=docker.io/library/php:8.2.29-fpm-trixie" \
     container
 
 images+=("${repobase}/php8.2-fpm")
@@ -41,7 +41,7 @@ podman build \
     --force-rm \
     --layers \
     --tag "${repobase}/php8.1-fpm" \
-    --build-arg "PHP_VERSION=docker.io/library/php:8.1.33-fpm" \
+    --build-arg "PHP_VERSION_IMAGE=docker.io/library/php:8.1.33-fpm-trixie" \
     container
 
 images+=("${repobase}/php8.1-fpm")
@@ -50,7 +50,7 @@ podman build \
     --force-rm \
     --layers \
     --tag "${repobase}/php8.0-fpm" \
-    --build-arg "PHP_VERSION=docker.io/library/php:8.0.30-fpm" \
+    --build-arg "PHP_VERSION_IMAGE=docker.io/library/php:8.0.30-fpm-bullseye" \
     container
 
 images+=("${repobase}/php8.0-fpm")
@@ -59,7 +59,7 @@ podman build \
     --force-rm \
     --layers \
     --tag "${repobase}/php7.4-fpm" \
-    --build-arg "PHP_VERSION=docker.io/library/php:7.4.33-fpm" \
+    --build-arg "PHP_VERSION_IMAGE=docker.io/library/php:7.4.33-fpm-bullseye" \
     container
 
 images+=("${repobase}/php7.4-fpm")

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,67 +1,110 @@
-ARG PHP_VERSION
-ENV PHP_VERSION=$PHP_VERSION
+# Define the PHP version via ARG
+ARG PHP_VERSION_IMAGE
+FROM ${PHP_VERSION_IMAGE}
 
-FROM $PHP_VERSION
+# Set environment variable for PHP version image
+ARG PHP_VERSION_IMAGE
+ENV PHP_VERSION_IMAGE=${PHP_VERSION_IMAGE}
 
-# Installation des dépendances nécessaires à la compilation
-RUN apt-get update && apt-get install -y \
-    libzip-dev \
-    libldap2-dev \
-    libtidy-dev \
-    libpng-dev \
-    libjpeg-dev \
-    libwebp-dev \
-    libfreetype6-dev \
-    libicu-dev \
+# Dépendances de build (compatibles Bullseye/Trixie)
+# latest php images does not support php7.4 and php8.0
+# we could stick to bullseyes but trixie is the current stable debian release
+# so we will try to make it work with both
+ARG PHP_BUILD_DEPS="\
     libbz2-dev \
-    libssl-dev \
-    libargon2-dev \
-    zlib1g-dev \
+    libfreetype6-dev \
     libgmp-dev \
-    libcurl4-openssl-dev \
-    libsqlite3-dev \
-    libxml2-dev \
+    libicu-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
     libpq-dev \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
-    && docker-php-ext-install \
-        soap \
-        sockets \
-        tidy \
-        ldap \
-        gd \
-        intl \
-        zip \
-        bcmath \
-        opcache \
-        exif \
-        pdo_mysql \
-        pdo_pgsql \
-        pgsql \
-        mysqli \
-        bz2 \
-        xml \
-    && apt-get purge -y \
-        libzip-dev \
-        libldap2-dev \
-        libtidy-dev \
-        libpng-dev \
-        libjpeg-dev \
-        libwebp-dev \
-        libfreetype6-dev \
-        libicu-dev \
-        libbz2-dev \
-        libssl-dev \
-        libargon2-dev \
-        zlib1g-dev \
-        libgmp-dev \
-        libcurl4-openssl-dev \
-        libsqlite3-dev \
-        libxml2-dev \
-        libpq-dev \
+    libwebp-dev \
+    libxml2-dev \
+    libxpm-dev \
+    libzip-dev \
+    librabbitmq-dev \
+    libprotobuf-dev \
+    protobuf-compiler \
+    libldap2-dev \
+    libsasl2-dev \
+    libtidy-dev \
+    libxslt1-dev \
+"
+
+# PHP extensions to install
+ARG PHP_EXTENSIONS="\
+    bcmath \
+    bz2 \
+    exif \
+    ftp \
+    gd \
+    gmp \
+    intl \
+    ldap \
+    mysqli \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    pgsql \
+    soap \
+    sockets \
+    tidy \
+    xml \
+    xsl \
+    zip \
+"
+
+# Detect Debian version and set runtime dependencies accordingly
+RUN set -eux; \
+    if echo "$PHP_VERSION_IMAGE" | grep -q "bullseye$"; then \
+        PHP_RUN_DEPS="\
+            libbz2-1.0 \
+            libfreetype6 \
+            libgmp10 \
+            libicu67 \
+            libjpeg62-turbo \
+            libpng16-16 \
+            libwebp6 \
+            libxml2 \
+            libxpm4 \
+            libxslt1.1 \
+            libzip4 \
+            libpq5 \
+            tidy \
+        "; \
+    elif echo "$PHP_VERSION_IMAGE" | grep -q "trixie$"; then \
+        PHP_RUN_DEPS="\
+            libbz2-1.0 \
+            libfreetype6 \
+            libgmp10 \
+            libicu76 \
+            libjpeg62-turbo \
+            libpng16-16 \
+            libwebp7 \
+            libxml2 \
+            libxpm4 \
+            libxslt1.1 \
+            libzip5 \
+            libpq5 \
+            libtidy58 \
+        "; \
+    else \
+        echo "Unsupported Debian version in PHP_VERSION_IMAGE: $PHP_VERSION_IMAGE"; exit 1; \
+    fi; \
+    apt-get update && apt-get install -y --no-install-recommends \
+        $PHP_BUILD_DEPS \
+        $PHP_RUN_DEPS \
+    && docker-php-ext-configure gd \
+        --with-freetype=/usr \
+        --with-jpeg=/usr \
+        --with-webp=/usr \
+        --with-xpm=/usr \
+    && docker-php-ext-install -j$(nproc) $PHP_EXTENSIONS \
+    && apt-get remove -y $PHP_BUILD_DEPS \
     && apt-get autoremove -y \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && ldconfig
 
-# copie docker-php-ext-opcache.ini to  /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 COPY docker-php-ext-opcache.ini /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini


### PR DESCRIPTION
This pull request updates the PHP FPM container build process to use more specific and recent PHP base images, and refactors the Dockerfile to better support both Debian Bullseye and Trixie distributions.

During the verification @mrmarkuz pointed some php libraries were missing.


https://github.com/NethServer/dev/issues/7610