### PR TITLE
Add custom Nginx configuration with X-Forwarded-For support

### DIFF
--- a/imageroot/state/customs/nginx.conf
+++ b/imageroot/state/customs/nginx.conf
@@ -1,0 +1,31 @@
+error_log  /var/log/nginx/error.log notice;
+pid        /run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush on;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    # Find the real IP coming from traefik, not the real public IP
+    real_ip_header X-Forwarded-For;
+    set_real_ip_from 0.0.0.0/0;   # we are bound to 127.0.0.1, it is harmless
+    real_ip_recursive on;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+

--- a/imageroot/systemd/user/nginx.service
+++ b/imageroot/systemd/user/nginx.service
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/nginx.pid \
     --cidfile %t/nginx.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/webserver.pod-id --replace -d --name  nginx \
     --volume ./conf.d:/etc/nginx/conf.d:z --volume websites:/usr/share/nginx/html:Z \
+    --volume ./customs/nginx.conf:/etc/nginx/nginx.conf:z \
     ${NGINX_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/nginx.ctr-id -t 10
 ExecReload=/usr/local/bin/runagent expand-vhosts


### PR DESCRIPTION
Introduce a custom Nginx configuration file that includes the X-Forwarded-For directive and update the systemd service to use this configuration.

https://github.com/NethServer/dev/issues/7640


even on a local network we see the IP of the server coming to the nginx logs, the traefik log is correc

without the fix (`192.168.12.110` is the external IP of the server, `192.168.13.25` is my client)

```
Sep 22 10:11:46 R1-pve.rocky9-pve.org nginx[3018330]: 192.168.12.110 - - [22/Sep/2025:08:11:46 +0000] "GET /phpinfo.php HTTP/1.1" 200 99208 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36" "192.168.13.25"
Sep 22 10:11:46 R1-pve.rocky9-pve.org traefik[3547]: 192.168.13.25 - - [22/Sep/2025:08:11:46 +0000] "GET /phpinfo.php HTTP/2.0" 200 99115 "-" "-" 79631 "webserver2-foo2.rocky9-pve.org-https@file" "http://127.0.0.1:20076" 3ms
```

with the fix

```
Sep 22 10:14:15 R1-pve.rocky9-pve.org nginx[3016093]: 192.168.13.25 - - [22/Sep/2025:08:14:15 +0000] "GET /phpinfo.php HTTP/1.1" 200 99427 "https://foo.rocky9-pve.org/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36" "192.168.13.25"
Sep 22 10:14:15 R1-pve.rocky9-pve.org traefik[3547]: 192.168.13.25 - - [22/Sep/2025:08:14:15 +0000] "GET /phpinfo.php HTTP/2.0" 200 99334 "-" "-" 79632 "webserver1-foo.rocky9-pve.org-https@file" "http://127.0.0.1:20074" 3ms
```