### PR TITLE
perf: parallelize PHP FPM/node image builds

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -88,7 +88,11 @@ for (( i=0; i<${#PHP_VERSIONS[@]}; i+=2 )); do
     fi
 done
 
-# Launch Node UI build in parallel with PHP builds
+# Launch Node UI build in parallel with PHP builds, counting it toward max_parallel
+if (( active_jobs >= max_parallel )); then
+    wait -n 2>/dev/null || true
+    active_jobs=$(( active_jobs - 1 ))
+fi
 echo "Starting UI build with Node..."
 (
     set +e

--- a/build-images.sh
+++ b/build-images.sh
@@ -127,8 +127,9 @@ for (( completed=0; completed<total; completed++ )); do
     echo "[${done_version}] BUILD OK"
 done
 
-# Reap all background build jobs to avoid zombies
-wait "${pids[@]}"
+# Reap any remaining background build jobs to avoid zombies.
+# Bare wait avoids exit 127 for jobs already reaped by wait -n during throttling.
+wait
 
 for (( i=0; i<${#PHP_VERSIONS[@]}; i+=2 )); do
     images+=("${repobase}/php${PHP_VERSIONS[$i]}-fpm")

--- a/build-images.sh
+++ b/build-images.sh
@@ -42,7 +42,7 @@ kill_all_builds() {
     done
 }
 # Full trap replaces the early one: also kill builds and close FD 3 on exit
-trap 'kill_all_builds; exec 3<&-; exec 3>&-; rm -rf "${tmpdir}"' EXIT
+trap 'kill_all_builds; exec 3<&-; rm -rf "${tmpdir}"' EXIT
 trap 'kill_all_builds; exit 130' INT
 trap 'kill_all_builds; exit 143' TERM
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -2,6 +2,8 @@
 
 # Terminate on error
 set -e
+# Enable job control so each background job gets its own process group (needed for kill_all_builds)
+set -m
 
 # Prepare variables for later use
 images=()
@@ -10,44 +12,129 @@ repobase="${REPOBASE:-ghcr.io/nethserver}"
 # Configure the image name
 reponame="webserver"
 
-# Function to build PHP FPM images
-build_php_image() {
-    local version=$1
-    local php_image=$2
-    
-    podman build \
-        --force-rm \
-        --layers \
-        --tag "${repobase}/php${version}-fpm" \
-        --build-arg "PHP_VERSION_IMAGE=${php_image}" \
-        container
-    
-    images+=("${repobase}/php${version}-fpm")
+# PHP versions to build: "version" "base-image" (pairs)
+declare -a PHP_VERSIONS=(
+    "8.5" "docker.io/library/php:8.5.4-fpm-bookworm"
+    "8.4" "docker.io/library/php:8.4.19-fpm-bookworm"
+    "8.3" "docker.io/library/php:8.3.30-fpm-bookworm"
+    "8.2" "docker.io/library/php:8.2.30-fpm-bookworm"
+    "8.1" "docker.io/library/php:8.1.34-fpm-bookworm"
+    "8.0" "docker.io/library/php:8.0.30-fpm-bullseye"
+    "7.4" "docker.io/library/php:7.4.33-fpm-bullseye"
+)
+
+# Secure temp dir for FIFO (avoids TOCTOU race of mktemp -u)
+tmpdir=$(mktemp -d)
+# Early trap: ensure tmpdir is cleaned even if mkfifo or exec below fails
+trap 'rm -rf "${tmpdir}"' EXIT
+result_fifo="${tmpdir}/result.fifo"
+mkfifo "${result_fifo}"
+# Open FIFO read-write to avoid blocking on open (no writer needed yet)
+exec 3<> "${result_fifo}"
+
+declare -a pids=()
+
+kill_all_builds() {
+    for pid in "${pids[@]}"; do
+        # With set -m each wrapper runs in its own process group (PGID=pid);
+        # kill -- -pid sends SIGTERM to the whole group (wrapper + nested subshell + podman + sed)
+        kill -- -"${pid}" 2>/dev/null || true
+    done
 }
+# Full trap replaces the early one: also kill builds and close FD 3 on exit
+trap 'kill_all_builds; exec 3<&-; exec 3>&-; rm -rf "${tmpdir}"' EXIT
+trap 'kill_all_builds; exit 130' INT
+trap 'kill_all_builds; exit 143' TERM
 
-# Build all PHP FPM images
-build_php_image "8.5" "docker.io/library/php:8.5.4-fpm-bookworm"
-build_php_image "8.4" "docker.io/library/php:8.4.19-fpm-bookworm"
-build_php_image "8.3" "docker.io/library/php:8.3.30-fpm-bookworm"
-build_php_image "8.2" "docker.io/library/php:8.2.30-fpm-bookworm"
-build_php_image "8.1" "docker.io/library/php:8.1.34-fpm-bookworm"
-build_php_image "8.0" "docker.io/library/php:8.0.30-fpm-bullseye"
-build_php_image "7.4" "docker.io/library/php:7.4.33-fpm-bullseye"
-
-# Create a new empty container image
+# Create a new empty container image and add static assets that don't depend on builds
 container=$(buildah from scratch)
-
-# Reuse existing nodebuilder-webserver container, to speed up builds
-if ! buildah containers --format "{{.ContainerName}}" | grep -q nodebuilder-webserver; then
-    echo "Pulling NodeJS runtime..."
-    buildah from --name nodebuilder-webserver -v "${PWD}:/usr/src:Z" docker.io/library/node:24-slim
-fi
-
-echo "Build static UI files with node..."
-buildah run --env="NODE_OPTIONS=--openssl-legacy-provider" nodebuilder-webserver sh -c "cd /usr/src/ui && yarn install && yarn build"
-
-# Add imageroot directory to the container image
 buildah add "${container}" imageroot /imageroot
+
+# Limit parallel builds to available CPU cores to avoid contention on CI runners
+max_parallel=$(nproc)
+active_jobs=0
+
+# Launch PHP FPM builds in parallel (throttled to max_parallel)
+for (( i=0; i<${#PHP_VERSIONS[@]}; i+=2 )); do
+    version="${PHP_VERSIONS[$i]}"
+    php_image="${PHP_VERSIONS[$((i+1))]}"
+    echo "Starting build php${version}-fpm (${php_image})..."
+    (
+        set +e
+        # Nested build subshell: set +e so PIPESTATUS is always reachable;
+        # exit with podman's status only — sed log-prefix failures are ignored.
+        (
+            set +e
+            podman build \
+                --force-rm \
+                --layers \
+                --cache-from "${repobase}/php${version}-fpm" \
+                --tag "${repobase}/php${version}-fpm" \
+                --build-arg "PHP_VERSION_IMAGE=${php_image}" \
+                container 2>&1 | sed -u "s/^/[php${version}] /"
+            exit "${PIPESTATUS[0]}"
+        ) &
+        build_pid=$!
+        # wait is valid here: build_pid is a direct child of this wrapper subshell.
+        # This captures the exit code even if build_pid is SIGKILLed — the kernel still provides it.
+        wait "${build_pid}"
+        printf "%s %d\n" "${version}" "$?" > "${result_fifo}" 2>/dev/null || true
+    ) &
+    pids+=("$!")
+    active_jobs=$(( active_jobs + 1 ))
+    if (( active_jobs >= max_parallel )); then
+        wait -n 2>/dev/null || true
+        active_jobs=$(( active_jobs - 1 ))
+    fi
+done
+
+# Launch Node UI build in parallel with PHP builds
+echo "Starting UI build with Node..."
+(
+    set +e
+    (
+        set +e
+        # Reuse existing nodebuilder-webserver container, to speed up builds
+        if ! buildah containers --format "{{.ContainerName}}" | grep -q nodebuilder-webserver; then
+            echo "[node] Pulling NodeJS runtime..."
+            buildah from --name nodebuilder-webserver -v "${PWD}:/usr/src:Z" docker.io/library/node:24-slim
+        fi
+        buildah run --env="NODE_OPTIONS=--openssl-legacy-provider" nodebuilder-webserver \
+            sh -c "cd /usr/src/ui && yarn install && yarn build" 2>&1 | sed -u "s/^/[node] /"
+        exit "${PIPESTATUS[0]}"
+    ) &
+    build_pid=$!
+    wait "${build_pid}"
+    printf "%s %d\n" "node" "$?" > "${result_fifo}" 2>/dev/null || true
+) &
+pids+=("$!")
+
+# Read results in completion order; stop everything on first failure
+total=${#pids[@]}
+for (( completed=0; completed<total; completed++ )); do
+    if ! read -r done_version done_result <&3; then
+        echo "[main] Failed to read build result from result FIFO"
+        exit 1
+    fi
+    if [[ -z "${done_version}" || -z "${done_result}" || ! "${done_result}" =~ ^-?[0-9]+$ ]]; then
+        echo "[main] Malformed build result from result FIFO: version='${done_version}' result='${done_result}'"
+        exit 1
+    fi
+    if [[ "${done_result}" -ne 0 ]]; then
+        echo "[${done_version}] BUILD FAILED - killing remaining builds..."
+        exit 1
+    fi
+    echo "[${done_version}] BUILD OK"
+done
+
+# Reap all background build jobs to avoid zombies
+wait "${pids[@]}"
+
+for (( i=0; i<${#PHP_VERSIONS[@]}; i+=2 )); do
+    images+=("${repobase}/php${PHP_VERSIONS[$i]}-fpm")
+done
+
+# Add UI dist produced by the Node build (must be after all builds complete)
 buildah add "${container}" ui/dist /ui
 # Setup the entrypoint, ask to reserve one TCP port with the label and set a rootless container
 buildah config --entrypoint=/ \

--- a/build-images.sh
+++ b/build-images.sh
@@ -95,7 +95,7 @@ echo "Starting UI build with Node..."
     (
         set +e
         # Reuse existing nodebuilder-webserver container, to speed up builds
-        if ! buildah containers --format "{{.ContainerName}}" | grep -q nodebuilder-webserver; then
+        if ! buildah containers --format "{{.ContainerName}}" | grep -qx nodebuilder-webserver; then
             echo "[node] Pulling NodeJS runtime..."
             buildah from --name nodebuilder-webserver -v "${PWD}:/usr/src:Z" docker.io/library/node:24-slim
         fi
@@ -109,13 +109,28 @@ echo "Starting UI build with Node..."
 ) &
 pids+=("$!")
 
-# Read results in completion order; stop everything on first failure
+# Read results in completion order; stop everything on first failure.
+# Use read -t to avoid blocking forever if a worker is SIGKILL'd and never writes
+# its result. On each timeout, check whether any tracked job is still alive; if
+# none are, the FIFO will never receive another line and we fail fast.
 total=${#pids[@]}
 for (( completed=0; completed<total; completed++ )); do
-    if ! read -r done_version done_result <&3; then
-        echo "[main] Failed to read build result from result FIFO"
-        exit 1
-    fi
+    while true; do
+        if read -r -t 30 done_version done_result <&3; then
+            break
+        fi
+        any_alive=0
+        for pid in "${pids[@]}"; do
+            if kill -0 "${pid}" 2>/dev/null; then
+                any_alive=1
+                break
+            fi
+        done
+        if [[ "${any_alive}" -eq 0 ]]; then
+            echo "[main] Timed out waiting for build result and no build jobs are running"
+            exit 1
+        fi
+    done
     if [[ -z "${done_version}" || -z "${done_result}" || ! "${done_result}" =~ ^-?[0-9]+$ ]]; then
         echo "[main] Malformed build result from result FIFO: version='${done_version}' result='${done_result}'"
         exit 1

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -66,7 +66,6 @@ ARG PHP_EXTENSIONS="\
 RUN set -eux \
     # --- Install runtime libraries depending on Debian codename ---
     && apt update \
-    && apt upgrade -y \
     && apt install -y ca-certificates openssl\
     &&  if echo "$PHP_VERSION_IMAGE" | grep -q "bullseye$"; then \
             apt install -y --no-install-recommends \


### PR DESCRIPTION
This pull request makes substantial improvements to the `build-images.sh` script by introducing parallelization for building PHP FPM images and the Node-based UI, improving error handling, and optimizing resource usage. It replaces sequential builds with a more robust and efficient approach that manages background jobs, handles failures gracefully, and ensures cleanup of temporary resources. There is also a minor change to the `Containerfile` to skip unnecessary upgrades during image builds.

**Build process improvements:**

* Refactored the PHP FPM image builds to run in parallel, limiting concurrency to the number of CPU cores, and using a FIFO for robust result collection and failure detection. This greatly speeds up the build process and ensures that any failure stops all remaining builds immediately.
* The Node-based UI build is now launched in parallel with the PHP builds, also reporting its result via the same mechanism.

**Error handling and cleanup:**

* Introduced comprehensive traps and job control (`set -m`) to ensure that all background jobs are properly terminated and temporary resources are cleaned up on exit or interruption. [[1]](diffhunk://#diff-abc769369f8124f5745e9ea8898f7989a1b1458439d50214f955690520421902R5-R6) [[2]](diffhunk://#diff-abc769369f8124f5745e9ea8898f7989a1b1458439d50214f955690520421902L13-R137)

**Containerfile optimization:**

* Removed the unnecessary `apt upgrade -y` step from the `Containerfile` to avoid time-consuming and potentially disruptive upgrades during image builds.