### PR TITLE
Update nginx image version to 1.30.2-alpine

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -161,7 +161,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=node:fwadm traefik@node:routeadm" \
     --label="org.nethserver.tcp-ports-demand=2" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/nginx:1.28.0-alpine docker.io/drakkan/sftpgo:v2.7.1-alpine" \
+    --label="org.nethserver.images=docker.io/nginx:1.30.2-alpine docker.io/drakkan/sftpgo:v2.7.1-alpine" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"


### PR DESCRIPTION
This pull request updates the base image version for `nginx` used in the container build process. The change ensures that the container is built with a more recent and secure version of `nginx`.

Dependency update:

* Updated the `org.nethserver.images` label in `build-images.sh` to use `docker.io/nginx:1.30.2-alpine` instead of `1.28.0-alpine`, keeping the `drakkan/sftpgo` version unchanged.