### PR TITLE
Refactor test-module workflow to run tests directly

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -12,15 +12,11 @@ on:
     types: [completed]
 
 jobs:
-  module:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == '' }}
-    uses: NethServer/ns8-github-actions/.github/workflows/module-info.yml@main
-  run_tests:
-    needs: module
-    uses: NethServer/ns8-github-actions/.github/workflows/test-on-digitalocean-infra.yml@main
+  run:
+    name: "Run tests"
+    uses: NethServer/ns8-github-actions/.github/workflows/test-module.yml@v1
     with:
-      args: "ghcr.io/${{needs.module.outputs.owner}}/${{needs.module.outputs.name}}:${{needs.module.outputs.tag}}"
-      repo_ref: ${{needs.module.outputs.sha}}
-      debug_shell: ${{ github.event.inputs.debug_shell == 'true' || false }}
+      ui_tests_strategy: on_renovate_ui_change
+      debug_shell: ${{ github.event.inputs.debug_shell == 'true' }}
     secrets:
       do_token: ${{ secrets.do_token }}


### PR DESCRIPTION
This pull request simplifies the workflow configuration in `.github/workflows/test-module.yml` by consolidating multiple jobs into a single job and updating the way tests are run. The most important changes are:

**Workflow simplification:**

* Removed the separate `module` and `run_tests` jobs, replacing them with a single `run` job that handles running tests directly using the `test-module.yml@v1` workflow.

**Configuration updates:**

* Updated the job inputs to use `ui_tests_strategy: on_renovate_ui_change` and simplified the `debug_shell` input assignment.

These changes streamline the CI process, making the workflow easier to maintain and less error-prone.