### PR TITLE
Update network options for webserver service

### DIFF
--- a/imageroot/systemd/user/webserver.service
+++ b/imageroot/systemd/user/webserver.service
@@ -21,7 +21,7 @@ ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/webserver.pid 
     --publish  ${SFTP_TCP_PORT}:2022 \
     --publish  127.0.0.1:${SFTPGO_TCP_PORT}:8080 \
     --replace \
-    --network=slirp4netns:allow_host_loopback=true
+    --network=slirp4netns:allow_host_loopback=true,port_handler=slirp4netns
 ExecStart=/usr/bin/podman pod start --pod-id-file %t/webserver.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file %t/webserver.pod-id -t 10
 ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file %t/webserver.pod-id


### PR DESCRIPTION
force to see the remote IP instead of 10.0.2.100

before
```
Jul 21 17:39:10 ns8-leader sftpgo[1202324]: {"level":"debug","time":"2026-07-21T15:39:10.986","sender":"connection_failed","client_ip":"10.0.2.100","username":"9002","login_type":"publickey","protocol":"SSH","error":"invalid credentials"}
Jul 21 17:39:11 ns8-leader sftpgo[1202324]: {"level":"debug","time":"2026-07-21T15:39:11.015","sender":"connection_failed","client_ip":"10.0.2.100","username":"9002","login_type":"publickey","protocol":"SSH","error":"invalid credentials"}
```

after 

```
Jul 21 17:59:01 ns8-leader sftpgo[1204926]: {"level":"debug","time":"2026-07-21T15:59:01.953","sender":"connection_failed","client_ip":"86.201.48.4","username":"9002","login_type":"publickey","protocol":"SSH","error":"invalid credentials"}
Jul 21 17:59:01 ns8-leader sftpgo[1204926]: {"level":"debug","time":"2026-07-21T15:59:01.984","sender":"connection_failed","client_ip":"86.201.48.4","username":"9002","login_type":"publickey","protocol":"SSH","error":"invalid credentials"}
```