### PR TITLE
fix(ui): dedupe carbon-components under yarn v4 to fix blank page

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -41,5 +41,9 @@
     "sass-loader": "^10.1.1",
     "vue-template-compiler": "^2.6.11"
   },
+  "resolutions": {
+    "carbon-components": "10.58.15",
+    "@carbon/icon-helpers": "10.76.0"
+  },
   "packageManager": "yarn@4.17.1"
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1257,16 +1257,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icon-helpers@npm:^10.37.0":
-  version: 10.73.0
-  resolution: "@carbon/icon-helpers@npm:10.73.0"
-  dependencies:
-    "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/01aed643924a9ac2cd42b2a6db649b1eaada321fa718174abdcaf936a23ae161c9d5d33755e798753fb0da701ea40115b478202b86a179c8bde9435f0b2a26bf
-  languageName: node
-  linkType: hard
-
-"@carbon/icon-helpers@npm:^10.76.0":
+"@carbon/icon-helpers@npm:10.76.0":
   version: 10.76.0
   resolution: "@carbon/icon-helpers@npm:10.76.0"
   dependencies:
@@ -3634,19 +3625,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"carbon-components@npm:10.58.5":
-  version: 10.58.5
-  resolution: "carbon-components@npm:10.58.5"
-  dependencies:
-    "@carbon/telemetry": "npm:0.1.0"
-    flatpickr: "npm:4.6.1"
-    lodash.debounce: "npm:^4.0.8"
-    warning: "npm:^3.0.0"
-  checksum: 10c0/8b95779e8f3d38da13b5e72d1ae2fb325705e236993447f16c65b4955138079ff29572eb5eb886c59c8f7bee9085f22c5a8a06453043dbc741724c6f59412100
-  languageName: node
-  linkType: hard
-
-"carbon-components@npm:^10.41.0":
+"carbon-components@npm:10.58.15":
   version: 10.58.15
   resolution: "carbon-components@npm:10.58.15"
   dependencies:


### PR DESCRIPTION
## Problem

One webserver instance rendered a blank page in cluster-admin while another worked, both on the same 1.3.8 UI bundle. The blank instance had PHP enabled; the working one did not.

## Root cause

Since the yarn v4 migration, `ui/yarn.lock` carried two copies of `carbon-components` (10.58.15 from the direct `^10.41.0` dependency, and 10.58.5 pinned exactly by `@carbon/vue`) and two copies of `@carbon/icon-helpers`. yarn v4's node-modules linker keeps both nested; yarn v1 collapsed them to one. Two `carbon-components` in one bundle double-register global components and throw at render time, but only when a component from the second copy instantiates. The PHP-rich status render hits that path; the minimal render does not. Hence one instance blank, one fine.

## Fix

Add a `resolutions` block pinning `carbon-components` and `@carbon/icon-helpers` to a single version each. No declared dependency or devDependency version changes; yarn v4 is kept. Restores the single-copy resolution that yarn v1 produced.

## Test

- `yarn install`: single `carbon-components` and single `@carbon/icon-helpers` in the lock
- `NODE_OPTIONS=--openssl-legacy-provider yarn build`: exit 0, dist complete
- [ ] deploy to the PHP-enabled instance, confirm the status page renders
- [ ] confirm the non-PHP instance still renders