### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/nginx.service
+++ b/imageroot/systemd/user/nginx.service
@@ -4,8 +4,8 @@ BindsTo=webserver.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/nginx.pid %t/nginx.ctr-id

--- a/imageroot/systemd/user/phpfpm@.service
+++ b/imageroot/systemd/user/phpfpm@.service
@@ -2,27 +2,27 @@
 Description=Podman  php%i-fpm.service
 BindsTo=webserver.service
 After=nginx.service
-ConditionDirectoryNotEmpty=%S/state/php%i-fpm-custom.d/
+ConditionDirectoryNotEmpty=%E/state/php%i-fpm-custom.d/
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/image_url_tag.env
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+EnvironmentFile=%E/state/image_url_tag.env
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/php%i-fpm.pid %t/php%i-fpm.ctr-id
-ExecStartPre=/usr/bin/mkdir -p %S/state/php%i-fpm-custom.d
+ExecStartPre=/usr/bin/mkdir -p %E/state/php%i-fpm-custom.d
 ExecStartPre=/usr/local/bin/runagent discover-smarthost
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/php%i-fpm.pid \
     --cidfile %t/php%i-fpm.ctr-id --cgroups=no-conmon \
     --pod-id-file %t/webserver.pod-id --replace -d --name  php%i-fpm \
     --volume websites:/var/www/html:z \
-    --volume %S/state/php%i-fpm-custom.d:/usr/local/etc/php-fpm.d:z \
-    --env-file %S/state/smarthosts/smarthost.env \
+    --volume %E/state/php%i-fpm-custom.d:/usr/local/etc/php-fpm.d:z \
+    --env-file %E/state/smarthosts/smarthost.env \
     ghcr.io/nethserver/php%i-fpm:${IMAGE_URL_TAG}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/php%i-fpm.ctr-id -t 10
-ExecReload=/usr/bin/mkdir -p %S/state/php%i-fpm-custom.d
+ExecReload=/usr/bin/mkdir -p %E/state/php%i-fpm-custom.d
 ExecReload=/usr/bin/podman kill -s USR2 php%i-fpm
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/php%i-fpm.ctr-id
 PIDFile=%t/php%i-fpm.pid

--- a/imageroot/systemd/user/sftpgo.service
+++ b/imageroot/systemd/user/sftpgo.service
@@ -4,8 +4,8 @@ After=nginx.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/mkdir -vp crontabs
@@ -17,7 +17,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/sftpgo.pid \
     --volume sftpgo_backups:/srv/sftpgo/backups:Z \
     --volume sftpgo_config:/var/lib/sftpgo:Z \
     --volume ./crontabs:/var/spool/cron/crontabs:Z \
-    --volume %S/state/sftpgo.conf.d/admin.json:/etc/sftpgo/admin.json:Z \
+    --volume %E/state/sftpgo.conf.d/admin.json:/etc/sftpgo/admin.json:Z \
     --env SFTPGO_LOADDATA_FROM=/etc/sftpgo/admin.json \
     --env SFTPGO_HTTPD__WEB_ROOT=${TRAEFIK_PATH}\
     --env SFTPGO_SFTPD__ENABLED_SSH_COMMANDS=rsync,scp \

--- a/imageroot/systemd/user/webserver.service
+++ b/imageroot/systemd/user/webserver.service
@@ -10,7 +10,7 @@ Before=nginx.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=-%S/state/environment
+EnvironmentFile=-%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/webserver.pid %t/webserver.pod-id


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host